### PR TITLE
Adding environment variables for the MySQL and Redis connection param…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2020-12-11
+
+### Changed
+
+- Introduced environment variables for such things as MySQL & Redis connection parameters.
+
 ## [1.0.5] - 2020-12-11
 
 ### Changed
@@ -48,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples of gateway + 2 federated services
 
 [unreleased]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.5...HEAD
+[1.0.6]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.4...v1.0.6
 [1.0.5]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.2...v1.0.3

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ Open http://localhost:6001
 We rely on docker network and uses hostnames from `docker-compose.yml`.
 Check `app/config.js` to see credentials that node service uses to connect to mysql & redis and change it if you install it with own setup. If you use dynamic service discovery (consul/etcd), edit `diplomat.js`
 
+`app/config.js` will look for the following environment variables and will use their values if available for connecting to MySQL and Redis. The names of the
+variables should be self-explanatory.
+
+```shell
+DB_HOST (defaults to 'gql-schema-registry-db')
+DB_USERNAME (defaults to 'root')
+DB_PASSWORD (defaults to 'root')
+DB_PORT (defaults to 3306)
+
+REDIS_HOST (defaults to 'gql-schema-registry-redis')
+REDIS_PORT (defauts to 6379)
+REDIS_USERNAME (defaults to '')
+REDIS_SECRET (defaults to '')
+```
+
 ## Use cases
 
 ### Validating schema on deploy
@@ -69,7 +84,7 @@ Backend (`/app` folder)
 - nodejs 14
 - express, hapi/joi
 - apollo-server-express, dataloader
-- redis 3
+- redis 6
 - knex
 - mysql 8
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ REDIS_USERNAME (defaults to '')
 REDIS_SECRET (defaults to '')
 ```
 
+`ASSETS_URL` is another environment variable that can be configured to control the url that web assets are served from. This can be used either when running the Node process locally in development mode,
+or when the registry sits behind a reverse proxy.
+
 ## Use cases
 
 ### Validating schema on deploy

--- a/app/config.js
+++ b/app/config.js
@@ -5,16 +5,16 @@ module.exports = {
 
 	serviceDiscovery: {
 		'gql-schema-registry-db': {
-			host: 'gql-schema-registry-db',
-			port: '3306',
-			username: 'root',
-			secret: 'root',
+			host: process.env.DB_HOST || 'gql-schema-registry-db',
+			port: process.env.DB_PORT || '3306',
+			username: process.env.DB_USERNAME || 'root',
+			secret: process.env.DB_SECRET || 'root',
 		},
 		'gql-schema-registry-redis': {
-			host: 'gql-schema-registry-redis',
-			port: '6379',
-			username: '',
-			secret: '',
+			host: process.env.REDIS_HOST || 'gql-schema-registry-redis',
+			port: process.env.REDIS_PORT || '6379',
+			username: process.env.REDIS_USERNAME || '',
+			secret: process.env.REDIS_SECRET || '',
 		},
 	},
 };

--- a/app/config.js
+++ b/app/config.js
@@ -13,7 +13,6 @@ module.exports = {
 		'gql-schema-registry-redis': {
 			host: process.env.REDIS_HOST || 'gql-schema-registry-redis',
 			port: process.env.REDIS_PORT || '6379',
-			username: process.env.REDIS_USERNAME || '',
 			secret: process.env.REDIS_SECRET || '',
 		},
 	},

--- a/app/redis/index.js
+++ b/app/redis/index.js
@@ -14,7 +14,14 @@ const redisWrapper = {
 			return this.redisInstance;
 		}
 
+		const { host, port, password } = await diplomat.getServiceInstance(
+			redisServiceName
+		);
+
 		const redisOptions = {
+			host: host,
+			port: port,
+			password: password,
 			db: 2,
 			retry_strategy: (options) => {
 				if (options.error && options.error.code === 'ECONNREFUSED') {
@@ -27,11 +34,8 @@ const redisWrapper = {
 				return Math.min(options.attempt * 100, 3000);
 			},
 		};
-		const { host, port } = await diplomat.getServiceInstance(
-			redisServiceName
-		);
 
-		this.redisInstance = redis.createClient(port, host, redisOptions);
+		this.redisInstance = redis.createClient(redisOptions);
 
 		this.redisInstance.on('ready', redisWrapper.onReady);
 		this.redisInstance.on('connect', redisWrapper.onConnect);

--- a/app/router/assets.js
+++ b/app/router/assets.js
@@ -1,6 +1,3 @@
-const fs = require('fs');
-const path = require('path');
-
 exports.router = (router) => {
 	const webpack = require('webpack');
 	const devWebpackConfig = require('../../webpack.config')({
@@ -15,7 +12,7 @@ exports.router = (router) => {
 };
 
 exports.indexHtml = () => {
-	const assetsDomain = 'localhost:6001';
+	const assetsDomain = process.env.ASSETS_DOMAIN || 'localhost:6001';
 	const assetsVersion = 'latest';
 
 	return function indexHtml(req, res) {

--- a/app/router/assets.js
+++ b/app/router/assets.js
@@ -12,7 +12,7 @@ exports.router = (router) => {
 };
 
 exports.indexHtml = () => {
-	const assetsDomain = process.env.ASSETS_DOMAIN || 'localhost:6001';
+	const assetsUrl = process.env.ASSETS_URL || 'localhost:6001';
 	const assetsVersion = 'latest';
 
 	return function indexHtml(req, res) {
@@ -25,12 +25,12 @@ exports.indexHtml = () => {
     <meta name="referrer" content="no-referrer" />
     <title>Schema Registry</title>
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i,700,700i" rel="stylesheet">
-    ${`<link rel="stylesheet" type="text/css" href="http://${assetsDomain}/assets/management-ui-standalone.css?v=${assetsVersion}">`}
+    ${`<link rel="stylesheet" type="text/css" href="http://${assetsUrl}/assets/management-ui-standalone.css?v=${assetsVersion}">`}
   </script>
   </head>
   <body style="margin:0;padding:0;">
     <div id="root"></div>
-    <script src="http://${assetsDomain}/assets/management-ui-standalone.js?v=${assetsVersion}" crossorigin></script>
+    <script src="http://${assetsUrl}/assets/management-ui-standalone.js?v=${assetsVersion}" crossorigin></script>
   </body>
   </html>`);
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-registry",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Graphql schema registry",
   "main": "schema-registry.js",
   "scripts": {


### PR DESCRIPTION
…eters. Also adding an env var for the 'assetsDomain', allowing to work locally without having to build the docker container.

## Problem

What is being solved?
Allowing to connect to MySQL or Redis instances outside of the docker-compose setup.

## Changes

- Modified app/config.js to look for the env vars
- Also modified app/router/assets.js to allow parameterizing the assets domain:port when running the schema registry outside docker-compose.
- Updated the README file with the new environment variables information.
