### PR TITLE
Modifying the REST DELETE Schema API to delete by schema id, matching…

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,13 @@ Compares schemas and finds breaking or dangerous changes between provided and la
 - version
 - type_defs
 
-#### DELETE /schema/delete
+#### DELETE /schema/delete/:schemaId
 
 Deletes specified schema
 
 ##### Input params
 
-- name
-- version
+- schemaId
 
 #### GET /persisted_query
 

--- a/app/router/index.js
+++ b/app/router/index.js
@@ -25,7 +25,7 @@ router.post('/schema/compose', asyncWrap(schema.compose));
 router.post('/schema/push', asyncWrap(schema.push));
 router.post('/schema/diff', asyncWrap(schema.diff));
 
-router.delete('/schema/delete', asyncWrap(schema.delete));
+router.delete('/schema/delete/:schemaId', asyncWrap(schema.delete));
 router.post('/schema/validate', asyncWrap(schema.validate));
 
 module.exports = router;

--- a/app/router/schema.js
+++ b/app/router/schema.js
@@ -75,15 +75,7 @@ exports.validate = async (req, res) => {
 };
 
 exports.delete = async (req, res) => {
-	const body = Joi.attempt(
-		req.body,
-		Joi.object().keys({
-			name: Joi.string().min(3).max(200),
-			version: Joi.string().min(1).max(100),
-		})
-	);
-
-	await deactivateSchema({ ...body });
+	await deactivateSchema({ id: req.params.schemaId });
 
 	return res.json({
 		success: true,


### PR DESCRIPTION
… the GraphQL version.

## Problem

What is being solved?
The REST DELETE Schema API was expecting a service name + version parameters, while the underlying DB update code was expecting a schema ID, which resulted in a 500 Internal Server error. So modified the DELETE API to accept a Schema ID parameter, matching the GraphQL version.

## Changes

- Changed the REST DELETE controller to accept a schemaId as a path parameter
- Modified the documentation in the README accordingly.
