### PR TITLE
Fix default database service name

### DIFF
--- a/app/database/index.js
+++ b/app/database/index.js
@@ -2,7 +2,7 @@ const diplomat = require('../diplomat');
 const logger = require('../logger');
 
 const DB_SCHEMA_REGISTRY =
-	process.env.DB_SCHEMA_REGISTRY || 'db-schema_registry';
+	process.env.DB_SCHEMA_REGISTRY || 'gql-schema-registry-db';
 const knex = require('knex');
 
 function cleanupSQL(sql) {


### PR DESCRIPTION
## Problem

Currently you need to hardcode DB_SCHEMA_REGISTRY = "gql-schema-registry-db" to run this. Otherwise it fails on startup:
```
Service failed to warm up: undefined service db-schema_registry networkaddress {
  original_error: Error: undefined service db-schema_registry networkaddress
```

## Changes

Matching the value in service discovery:
https://github.com/pipedrive/graphql-schema-registry/blob/951390b10bc18b153f6be6c3e4ab8874ebca73d0/app/config.js#L7
