### PR TITLE
Allow mysql database name to be set with DB_NAME

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -9,6 +9,7 @@ module.exports = {
 			port: process.env.DB_PORT || '3306',
 			username: process.env.DB_USERNAME || 'root',
 			secret: process.env.DB_SECRET || 'root',
+			name: process.env.DB_NAME || 'schema_registry',
 		},
 		'gql-schema-registry-redis': {
 			host: process.env.REDIS_HOST || 'gql-schema-registry-redis',

--- a/app/database/index.js
+++ b/app/database/index.js
@@ -35,6 +35,7 @@ const connection = knex({
 			port,
 			username,
 			secret,
+			name,
 		} = await diplomat.getServiceInstance(DB_SCHEMA_REGISTRY);
 
 		logger.info(`connecting to DB ${host}:${port}`);
@@ -44,7 +45,7 @@ const connection = knex({
 			port,
 			user: username,
 			password: secret,
-			database: 'schema_registry',
+			database: name,
 			connectTimeout: 5000,
 			expirationChecker: () => true,
 		};


### PR DESCRIPTION
## Problem

Currently the database name is hardcoded to `schema_registry`. 

## Changes

Allow the database name to be overridden with an additional environment variable DB_NAME
