### PR TITLE
Updated mysql environment variables in docker-compose.yaml…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.2]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.1...v1.0.1
 [1.0.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.0...v1.0.0
+
+
+[Unreleased]: https://github.com/rsteig/graphql-schema-registry/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/rsteig/graphql-schema-registry/tree/v1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.2]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.1...v1.0.1
 [1.0.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.0...v1.0.0
-
-
-[Unreleased]: https://github.com/rsteig/graphql-schema-registry/compare/v1.1.2...HEAD
-[1.1.2]: https://github.com/rsteig/graphql-schema-registry/tree/v1.1.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     command: mysqld --default-authentication-plugin=mysql_native_password --skip-mysqlx
     environment:
       SERVICE_3306_NAME: gql-schema-registry-db
-      MYSQL_USER: root
-      MYSQL_PASSWORD: root
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: schema_registry
     ports:


### PR DESCRIPTION
…to fix premature exit in mysql container on first run

## Problem

On a clean checkout, with all previous volumes and containers removed, the project will fail the first time docker-compose is ran due to a database initialization failure. 

```
gql-schema-registry-db_1     | 2020-12-20 07:48:03+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.22-1debian10 started.
gql-schema-registry-db_1     | 2020-12-20 07:48:03+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
gql-schema-registry-db_1     | 2020-12-20 07:48:03+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.22-1debian10 started.
gql-schema-registry-db_1     | 2020-12-20 07:48:03+00:00 [Note] [Entrypoint]: Initializing database files
gql-schema-registry-db_1     | 2020-12-20T07:48:03.457606Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.22) initializing of server in progress as process 43
gql-schema-registry-db_1     | 2020-12-20T07:48:03.464637Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
gql-schema-registry-db_1     | 2020-12-20T07:48:04.465568Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
gql-schema-registry-db_1     | 2020-12-20T07:48:08.242325Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
gql-schema-registry-db_1     | 2020-12-20 07:48:13+00:00 [Note] [Entrypoint]: Database files initialized
gql-schema-registry-db_1     | 2020-12-20 07:48:13+00:00 [Note] [Entrypoint]: Starting temporary server
gql-schema-registry-db_1     | 2020-12-20T07:48:14.042916Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.22) starting as process 88
gql-schema-registry-db_1     | 2020-12-20T07:48:14.077536Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
gql-schema-registry-db_1     | 2020-12-20T07:48:14.315694Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
gql-schema-registry-db_1     | 2020-12-20T07:48:14.606723Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
gql-schema-registry-db_1     | 2020-12-20T07:48:14.607552Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
gql-schema-registry-db_1     | 2020-12-20T07:48:14.615594Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
gql-schema-registry-db_1     | 2020-12-20T07:48:14.655665Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.22'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server - GPL.
gql-schema-registry-db_1     | 2020-12-20 07:48:14+00:00 [Note] [Entrypoint]: Temporary server started.
gql-schema-registry-db_1     | Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
gql-schema-registry-db_1     | Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
gql-schema-registry-db_1     | Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
gql-schema-registry-db_1     | Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
gql-schema-registry-db_1     | 2020-12-20 07:48:16+00:00 [Note] [Entrypoint]: Creating database schema_registry
gql-schema-registry-db_1     | 2020-12-20 07:48:16+00:00 [Note] [Entrypoint]: Creating user root
gql-schema-registry-db_1     | ERROR 1396 (HY000) at line 1: Operation CREATE USER failed for 'root'@'%'
graphql-schema-registry_gql-schema-registry-db_1 exited with code 1
```
## Changes

- removed MYSQL_USER and MYSQL_PASSWORD entries from docker-compose environment values as they are unused and cause the container to error on initialization. 
