### PR TITLE
Migrations options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2020-12-22
+### Added
+- New environment variable controlling the execution of DB migrations on application startup.
+- New `npm` command to execute DB migrations explicitly.
+
 ## [1.1.3] - 2020-12-20
 ### Fixed
 - fixed db credentials in docker-compose.yaml causing container startup issues, relying on root:root only now
@@ -83,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frontend app
 - Examples of gateway + 2 federated services
 
-[unreleased]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.0.3...HEAD
+[unreleased]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.1.3...HEAD
 
 [1.1.3]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/pipedrive/graphql-schema-registry/compare/v1.1.1...v1.1.2

--- a/README.md
+++ b/README.md
@@ -43,23 +43,20 @@ Open http://localhost:6001
 We rely on docker network and uses hostnames from `docker-compose.yml`.
 Check `app/config.js` to see credentials that node service uses to connect to mysql & redis and change it if you install it with own setup. If you use dynamic service discovery (consul/etcd), edit `diplomat.js`
 
-`app/config.js` will look for the following environment variables and will use their values if available for connecting to MySQL and Redis. The names of the
-variables should be self-explanatory.
+The following are the different environment variables that are looked up that allow configuring the schema registry in different ways.
 
-```shell
-DB_HOST (defaults to 'gql-schema-registry-db')
-DB_USERNAME (defaults to 'root')
-DB_SECRET (defaults to 'root')
-DB_PORT (defaults to 3306)
-DB_NAME (defaults to 'schema-registry')
-
-REDIS_HOST (defaults to 'gql-schema-registry-redis')
-REDIS_PORT (defauts to 6379)
-REDIS_SECRET (defaults to '')
-```
-
-`ASSETS_URL` is another environment variable that can be configured to control the url that web assets are served from. This can be used either when running the Node process locally in development mode,
-or when the registry sits behind a reverse proxy.
+|Variable Name| Description | Default
+|------|------|------|
+| DB_HOST | Host name of the MySQL server | gql-schema-registry-db |
+| DB_USERNAME | Username to connect to MySQL | root |
+| DB_SECRET | Password used to connect to MySQL | root |
+| DB_PORT | Port used when connecting to MySQL | 3306 |
+| DB_NAME | Name of the MySQL database to connect to | schema-registry |
+| DB_EXECUTE_MIGRATIONS | Controls whether DB migrations are executed upon registry startup or not | true |
+| REDIS_HOST | Host name of the Redis server | gql-schema-registry-redis |
+| REDIS_PORT | Port used when connecting to Redis | 6379 |
+| REDIS_SECRET | Password used to connect to MySQL | Empty |
+| ASSETS_URL | Controls the url that web assets are served from | localhost:6001 |
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ npm install knex -g
 knex migrate:make my_migration_name_here --migrations-directory migrations
 ```
 
+If not using the default configuration of executing DB migrations on registry startup, you can run the following `npm`
+command prior to starting the registry:
+
+```bash
+npm run migrate-db
+```
+
+The command can be prefixed with any environment variable necessary to configure your DB connection, such as:
+
+```bash
+DB_HOST=my-db-host DB_PORT=6000 npm run migrate-db
+```
+
 ### Contribution
 
 - Before making PR, make sure to run `npm run version` & fill [CHANGELOG](CHANGELOG.md)

--- a/app/config.js
+++ b/app/config.js
@@ -5,6 +5,7 @@ module.exports = {
 
 	serviceDiscovery: {
 		'gql-schema-registry-db': {
+			client: 'mysql2',
 			host: process.env.DB_HOST || 'gql-schema-registry-db',
 			port: process.env.DB_PORT || '3306',
 			username: process.env.DB_USERNAME || 'root',

--- a/app/database/index.js
+++ b/app/database/index.js
@@ -21,8 +21,17 @@ function logQueryError(error, { sql }) {
 	logger.debug(`DB error ${error} on query : ${sql}`);
 }
 
+const {
+	client,
+	host,
+	port,
+	username,
+	secret,
+	name,
+} = diplomat.getServiceInstance(DB_SCHEMA_REGISTRY);
+
 const connection = knex({
-	client: 'mysql2',
+	client: client,
 	log: {
 		warn: logger.info,
 		error: logger.error,
@@ -30,14 +39,6 @@ const connection = knex({
 		debug: logger.debug,
 	},
 	connection: async () => {
-		const {
-			host,
-			port,
-			username,
-			secret,
-			name,
-		} = await diplomat.getServiceInstance(DB_SCHEMA_REGISTRY);
-
 		logger.info(`connecting to DB ${host}:${port}`);
 
 		return {

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,22 @@
+const diplomat = require('./app/diplomat')
+
+const DB_SCHEMA_REGISTRY = process.env.DB_SCHEMA_REGISTRY || 'gql-schema-registry-db';
+const {
+	client,
+	host,
+	port,
+	username,
+	secret,
+	name,
+} = diplomat.getServiceInstance(DB_SCHEMA_REGISTRY);
+
+module.exports = {
+	client: client,
+	connection: {
+		host: host,
+		port: port,
+		database: name,
+		user: username,
+		password: secret
+	}
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-registry",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Graphql schema registry",
   "main": "schema-registry.js",
   "scripts": {
@@ -10,7 +10,9 @@
     "format": "prettier --write '**/*.{js,jsx,json,md,yml,yaml,graphql}'",
     "version": "version-changelog CHANGELOG.md && changelog-verify CHANGELOG.md && git add CHANGELOG.md",
     "build": "rimraf dist && mkdirp dist && webpack --env.production --bail",
-    "docker-compose-validate": "docker-comply compose --file ./docker-compose.deploy.yml"
+    "docker-compose-validate": "docker-comply compose --file ./docker-compose.deploy.yml",
+    "migrate-db": "knex migrate:latest",
+    "new-db-migration": "knex migrate:make rename-me"
   },
   "repository": {
     "type": "git",

--- a/schema-registry.js
+++ b/schema-registry.js
@@ -18,9 +18,18 @@ logger.info(`Starting schema-registry...`);
 
 async function warmup() {
 	logger.info('Warming up');
+	logger.info(`Looking for environment variable DB_EXECUTE_MIGRATIONS  = ${process.env.DB_EXECUTE_MIGRATIONS}`);
+
+	const executeMigrations = (process.env.DB_EXECUTE_MIGRATIONS || 'true').trim();
+
+	logger.info(`Will execute DB migrations? ${executeMigrations}`);
 
 	try {
-		await require('./app/database').knex.migrate.latest();
+
+		if (executeMigrations === 'true') {
+			await require('./app/database').knex.migrate.latest();
+		}
+
 		await require('./app').init();
 
 		logger.info('Warm up complete');


### PR DESCRIPTION
## Problem

Adding a new environment variable that controls the DB migrations execution on registry startup. The default is to execute migrations on registry startup. Also adding an explicit `npm` command to execute DB migrations.

## Changes

- added a knexfile.js file to initialize knex migrations with DB connection parameters extracted from environment variables
- added npm script to explicitly execute DB migrations
