### PR TITLE
Modifying the environment variable ASSETS_URL to include the protocol…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The following are the different environment variables that are looked up that al
 | REDIS_HOST | Host name of the Redis server | gql-schema-registry-redis |
 | REDIS_PORT | Port used when connecting to Redis | 6379 |
 | REDIS_SECRET | Password used to connect to MySQL | Empty |
-| ASSETS_URL | Controls the url that web assets are served from | localhost:6001 |
+| ASSETS_URL | Controls the root url from which web assets are served from | http://localhost:6001 |
 
 ## Use cases
 

--- a/app/router/assets.js
+++ b/app/router/assets.js
@@ -12,7 +12,7 @@ exports.router = (router) => {
 };
 
 exports.indexHtml = () => {
-	const assetsUrl = process.env.ASSETS_URL || 'localhost:6001';
+	const assetsRootUrl = process.env.ASSETS_URL || 'http://localhost:6001';
 	const assetsVersion = 'latest';
 
 	return function indexHtml(req, res) {
@@ -25,12 +25,12 @@ exports.indexHtml = () => {
     <meta name="referrer" content="no-referrer" />
     <title>Schema Registry</title>
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i,700,700i" rel="stylesheet">
-    ${`<link rel="stylesheet" type="text/css" href="http://${assetsUrl}/assets/management-ui-standalone.css?v=${assetsVersion}">`}
+    ${`<link rel="stylesheet" type="text/css" href="${assetsRootUrl}/assets/management-ui-standalone.css?v=${assetsVersion}">`}
   </script>
   </head>
   <body style="margin:0;padding:0;">
     <div id="root"></div>
-    <script src="http://${assetsUrl}/assets/management-ui-standalone.js?v=${assetsVersion}" crossorigin></script>
+    <script src="${assetsRootUrl}/assets/management-ui-standalone.js?v=${assetsVersion}" crossorigin></script>
   </body>
   </html>`);
 	};


### PR DESCRIPTION
… (HTTP|HTTPS), in order to allow serving assets over HTTPS.

## Problem

Assets can only be served over HTTP, which is a problem in environments where all content has to be served over HTTPS, including assets. So this change modifies the ASSETS_URL env var to include the protocol.

## Changes

- modified assets.js and how the ASSETS_URL env var is used