### PR TITLE
Build a standalone container to use in other environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Dockerfile now builds a self-contained deployment artefact.
+
+### Changed
+
+- Removed debug logging in production environments.
+
 ## [1.2.2] - 2021-02-01
 ### Changed
 - Assets can now be served from compiled version, depending on NODE_ENV env var

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,40 @@
-FROM node:14-alpine
-
+FROM node:14-alpine as builder-client
+ARG env=production
+ENV npm_config_cache=/tmp/.npm
+RUN mkdir -p /tmp/.npm /app \
+    && chown nobody:nobody /tmp/.npm /app
+WORKDIR /app
 USER nobody
 
-# ensure all directories exist
-WORKDIR /app
+ADD package.json package-lock.json ./
+RUN npm install
+ADD webpack.config.js babel.config.js ./
+ADD client ./client
+RUN npx webpack-cli --env=${env} --mode=${env}
 
+
+FROM node:14-alpine as builder-app
+ARG env=production
+ENV npm_config_cache=/tmp/.npm
+ENV NODE_ENV=${env}
+RUN mkdir -p /app && chown nobody:nobody /app
+COPY --from=builder-client /tmp/.npm /tmp/.npm
+WORKDIR /app
+USER nobody
+ADD package.json package-lock.json ./
+RUN npm install
+
+FROM node:14-alpine
+ARG env=production
+ENV NODE_ENV=${env}
+RUN mkdir -p /app && chown nobody:nobody /app
+USER nobody
+WORKDIR /app
+COPY . /app
+COPY --from=builder-client /app/dist /app/dist
+COPY --from=builder-app /app/node_modules /app/node_modules
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=3 CMD [ "node", "container-health.js" ]
 EXPOSE 3000
 
 CMD ["node", "schema-registry.js"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM node:14-alpine
+
+USER nobody
+
+# ensure all directories exist
+WORKDIR /app
+
+EXPOSE 3000
+
+CMD ["node", "schema-registry.js"]

--- a/app/database/index.js
+++ b/app/database/index.js
@@ -54,7 +54,9 @@ const connection = knex({
 	},
 });
 
-connection.on('query', logQuery);
+if (process.env.NODE_ENV != 'production') {
+	connection.on('query', logQuery);
+}
 connection.on('query-error', logQueryError);
 
 exports.knex = connection;

--- a/app/index.js
+++ b/app/index.js
@@ -37,7 +37,9 @@ app.get(`/health`, (req, res) => {
 });
 
 // log every request to the console in dev
-app.use(require('morgan')('dev'));
+if (process.env.NODE_ENV !== 'production') {
+	app.use(require('morgan')('dev'));
+}
 
 app.use(require('./router'));
 initGraphql(app);

--- a/container-health.js
+++ b/container-health.js
@@ -9,7 +9,7 @@ const options = {
 	// client port
 	port: 3000,
 	// health endpoint to call
-	path: '/health-schema-registry',
+	path: '/health',
 };
 
 const req = http.request(options, (response) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,9 @@ services:
           - 'gql-schema-registry-db'
 
   gql-schema-registry:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
     command:
       node_modules/nodemon/bin/nodemon.js --watch schema-registry.js --watch app
       --inspect=0.0.0.0:5850 schema-registry.js

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,5 +97,5 @@ const standalone = {
 };
 
 module.exports = (env) => [
-	merge(config(env), env.production ? standalone.prod : standalone.dev),
+	merge(config(env), env && env.production ? standalone.prod : standalone.dev),
 ];


### PR DESCRIPTION
## Problem

First of all, many thanks for this project! It looks like a very interesting approach for managing GraphQL schemas if you're not going the Apollo Studio route. 

What is being solved?

I was trying out the project and once it wanted to move it over to an environment with my own services, I started struggling a bit. In that context, I'm not interested in doing development on the registry, so the current approach in the compose file of mounting the source directory into the container is far from ideal.
To make this easier, this PR changes the Dockerfile so that it builds a static version of the assets [0] and composes a final container that only contains the client assets, app code and the non-dev dependencies. Doing this also revealed that morgan is currently specified as a dev-dependency, but was unconditionally used to produce debug logs even if `NODE_ENV` was set to `production`. I've fixed that along with one other instance where I saw debug logs leaking through in production envs.

The developer experience with docker-compose is unchanged, in case you were wondering.

---
[0] btw: Would you folks be interested in an PR that replaces the in-code index.html template with an index.html generated by Webpack using the HtmlWebpackPlugin?

## Changes

- added a Dockerfile that builds a container suitable for direct deployment into an existing environment 
- Added a few guards where debug logging leaked out with `NODE_ENV=production`, in particular, 
