### PR TITLE
Handling deactivated schemas when building the federated graph.

### DIFF
--- a/app/controller/schema.js
+++ b/app/controller/schema.js
@@ -22,7 +22,9 @@ async function getAndValidateSchema({ trx, services } = {}) {
 		}
 	);
 
-	composeAndValidateSchema(schemas);
+	if (schemas && schemas.length) {
+		composeAndValidateSchema(schemas);
+	}
 
 	return schemas;
 }
@@ -73,13 +75,15 @@ exports.diffSchemas = async ({ service }) => {
 	return await transact(async (trx) => {
 		const schemas = await getLastUpdatedForActiveServices({ trx });
 
-		const original = composeAndValidateSchema(schemas);
-		const updated = composeAndValidateSchema(
-			schemas
-				.filter((schema) => schema.name !== service.name)
-				.concat(service)
-		);
+		if (schemas && schemas.length) {
+			const original = composeAndValidateSchema(schemas);
+			const updated = composeAndValidateSchema(
+				schemas
+					.filter((schema) => schema.name !== service.name)
+					.concat(service)
+			);
 
-		return diff(original, updated);
+			return diff(original, updated);
+		}
 	});
 };

--- a/app/database/schema.js
+++ b/app/database/schema.js
@@ -47,11 +47,13 @@ const schemaModel = {
 						t4.is_active
 				 FROM \`container_schema\` as t1
 						  INNER JOIN (
-					 SELECT MAX(added_time) as max_added_time,
-							MAX(id)         as max_id,
-							service_id
-					 FROM \`container_schema\`
-					 GROUP BY service_id
+					 SELECT MAX(cs1.added_time) as max_added_time,
+							MAX(cs1.id)         as max_id,
+							cs1.service_id
+					 FROM \`container_schema\` cs1
+					 	INNER JOIN \`schema\` s1 on cs1.schema_id = s1.id
+					 WHERE s1.is_active <> 0
+					 GROUP BY cs1.service_id
 				 ) as t2 ON t2.service_id = t1.service_id
 						  INNER JOIN \`services\` t3 ON t3.id = t1.service_id
 						  INNER JOIN \`schema\` t4 ON t4.id = t1.schema_id

--- a/app/database/services.js
+++ b/app/database/services.js
@@ -36,14 +36,6 @@ const servicesModel = {
 		return service;
 	},
 
-	toggleService: async function ({ trx = knex, name }, isActive) {
-		return await trx('services')
-			.update({
-				is_active: isActive,
-			})
-			.where('name', name);
-	},
-
 	deleteService: async function ({ trx = knex, name }) {
 		return trx('services').delete().where('name', name);
 	},


### PR DESCRIPTION
## Problem

Deactivated schemas are considered when building the federated graph. This PR makes sure that only active schemas are used when building the federated graph.

## Changes

- modified the DB query in app/database/schema.js to filter out inactive schemas
- modified schema composition handling in a couple of places in app/controller/schema.js to deal with the possibility of having no schemas to federate
