### PR TITLE
emulate managed federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2021-05-22
+### Added
+
+- Service url storage to emulate managed federation
+
 ## [1.2.3] - 2021-02-22
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Graphql schema storage as dockerized on-premise service for federated graphql ga
 - Validates new schema to be compatible with other _running_ services
 - Provides UI for developers to see stored schema & its history diff
 - Stores & shows in UI persisted queries passed by the gateway for debugging
+- Stores service urls emulating managed federation: you no longer need to hardcode the services in your gateway's constructor, or rely on an additonal service (etcd, consul) for service discovery
 
 <img width="1309" alt="Screenshot 2020-08-31 at 15 40 43" src="https://user-images.githubusercontent.com/445122/91720806-65985c00-eba0-11ea-8763-986b9f3f166b.png">
 
@@ -168,6 +169,7 @@ Used by graphql gateway to fetch schema based on current containers
             "service_id": 3,
             "version": "ke9j34fuuei",
             "name": "service_a",
+            "url": "http://localhost:6111",
             "added_time": "2020-12-11T11:59:40.000Z",
             "type_defs": "\n\ttype Query {\n\t\thello: String\n\t}\n",
             "is_active": 1
@@ -177,6 +179,7 @@ Used by graphql gateway to fetch schema based on current containers
             "service_id": 4,
             "version": "v1",
             "name": "service_b",
+            "url": "http://localhost:6112",
             "added_time": "2020-12-14T18:51:04.000Z",
             "type_defs": "type Query {\n  world: String\n}\n",
             "is_active": 1
@@ -207,6 +210,14 @@ Validates and registers new schema for a service.
 }
 ```
 
+```json
+{
+  "name": "service_b",
+  "version": "jiaj51fu91k",
+  "type_defs": "\n\ttype Query {\n\t\tworld: String\n\t}\n",
+  "url": "http://service-b.develop.svc.cluster.local"
+}
+```
 #### POST /schema/validate
 
 Validates schema, without adding to DB

--- a/app/database/schema.js
+++ b/app/database/schema.js
@@ -58,10 +58,7 @@ const schemaModel = {
 						  INNER JOIN \`schema\` t4 ON t4.id = t1.schema_id
 				 WHERE t3.name IN (?)
 				   AND t3.id = t2.service_id
-				   AND (
-						 t4.added_time = t2.max_added_time OR
-						 t1.id = t2.max_id
-					 )
+				   AND t4.is_active = TRUE
 				 ORDER BY t1.service_id, t1.added_time DESC, t1.id DESC`,
 			[names]
 		);

--- a/app/database/schema.js
+++ b/app/database/schema.js
@@ -42,6 +42,7 @@ const schemaModel = {
 						t1.service_id,
 						t1.version,
 						t3.name,
+						t3.url,
 						t4.added_time,
 						t4.type_defs,
 						t4.is_active
@@ -113,6 +114,7 @@ const schemaModel = {
 			.select([
 				'container_schema.*',
 				'services.name',
+				'services.url',
 				'schema.is_active',
 				'schema.type_defs',
 			])
@@ -192,7 +194,11 @@ const schemaModel = {
 		let existingService = await getService({ trx, name: service.name });
 
 		if (!existingService) {
-			existingService = await insertService({ trx, name: service.name });
+			existingService = await insertService({ trx, name: service.name, url: service.url });
+		} else if (service.url && existingService.url != service.url ) {
+			await trx('services')
+				.where('id', '=', existingService.id)
+				.update({ url: service.url });
 		}
 
 		const serviceId = existingService.id;

--- a/app/database/schema.test.js
+++ b/app/database/schema.test.js
@@ -31,7 +31,7 @@ describe('app/database/schema.js', () => {
 				added_time: '2020-02-02T10:00:00.000Z',
 				is_active: 1,
 				name: 'xxx',
-				url: 'xxx,
+				url: 'xxx',
 			};
 
 			knexMock.raw = async () => [
@@ -80,7 +80,7 @@ describe('app/database/schema.js', () => {
 						added_time: time,
 						is_active: 1,
 						name: 'xxx',
-						url: 'xxx,
+						url: 'xxx',
 					},
 					correctVersion,
 				],

--- a/app/database/schema.test.js
+++ b/app/database/schema.test.js
@@ -31,6 +31,7 @@ describe('app/database/schema.js', () => {
 				added_time: '2020-02-02T10:00:00.000Z',
 				is_active: 1,
 				name: 'xxx',
+				url: 'xxx,
 			};
 
 			knexMock.raw = async () => [
@@ -43,6 +44,7 @@ describe('app/database/schema.js', () => {
 						added_time: '2020-01-01T09:00:00.000Z',
 						is_active: 1,
 						name: 'xxx',
+						url: 'xxx,
 					},
 					correctVersion,
 				],
@@ -65,6 +67,7 @@ describe('app/database/schema.js', () => {
 				added_time: time,
 				is_active: 1,
 				name: 'xxx',
+				url: 'xxx,
 			};
 
 			knexMock.raw = async () => [
@@ -77,6 +80,7 @@ describe('app/database/schema.js', () => {
 						added_time: time,
 						is_active: 1,
 						name: 'xxx',
+						url: 'xxx,
 					},
 					correctVersion,
 				],

--- a/app/database/services.js
+++ b/app/database/services.js
@@ -3,7 +3,7 @@ const { knex } = require('./index');
 const servicesModel = {
 	getActiveServices: async function ({ trx = knex } = {}) {
 		return trx('services')
-			.select('services.id', 'services.name')
+			.select('services.id', 'services.name', 'services.url')
 			.where('is_active', true);
 	},
 
@@ -24,8 +24,8 @@ const servicesModel = {
 		return service[0];
 	},
 
-	insertService: async function ({ trx = knex, name }) {
-		await trx('services').insert({ name });
+	insertService: async function ({ trx = knex, name, url }) {
+		await trx('services').insert({ name, url });
 
 		const service = await servicesModel.getService({ trx, name });
 

--- a/app/graphql/schema.js
+++ b/app/graphql/schema.js
@@ -49,6 +49,7 @@ module.exports = gql`
 	type Service {
 		id: Int!
 		name: String!
+		url: String
 
 		schemas(limit: Int, offset: Int, filter: String): [SchemaDefinition!]!
 	}

--- a/app/helpers/federation.js
+++ b/app/helpers/federation.js
@@ -16,7 +16,7 @@ exports.composeAndValidateSchema = (servicesSchemaMap) => {
 
 			return {
 				name: schema.name,
-				url: '',
+				url: schema.url,
 				typeDefs,
 			};
 		});

--- a/app/router/schema.js
+++ b/app/router/schema.js
@@ -49,6 +49,7 @@ exports.push = async (req, res) => {
 			name: Joi.string().min(3).max(200).required(),
 			version: Joi.string().min(1).max(100).required(),
 			type_defs: Joi.string().required(),
+			url: Joi.string().min(1).max(200),
 		})
 	);
 
@@ -65,6 +66,7 @@ exports.validate = async (req, res) => {
 			name: Joi.string().min(3).max(200).required(),
 			version: Joi.string().min(1).max(100).required(),
 			type_defs: Joi.string().required(),
+			url: Joi.string().min(1).max(200),
 		})
 	);
 

--- a/app/router/schema.js
+++ b/app/router/schema.js
@@ -49,7 +49,7 @@ exports.push = async (req, res) => {
 			name: Joi.string().min(3).max(200).required(),
 			version: Joi.string().min(1).max(100).required(),
 			type_defs: Joi.string().required(),
-			url: Joi.string().min(1).max(200),
+			url: Joi.string().uri().min(1).max(255).allow(''),
 		})
 	);
 
@@ -66,7 +66,7 @@ exports.validate = async (req, res) => {
 			name: Joi.string().min(3).max(200).required(),
 			version: Joi.string().min(1).max(100).required(),
 			type_defs: Joi.string().required(),
-			url: Joi.string().min(1).max(200),
+			url: Joi.string().uri().min(1).max(255).allow(''),
 		})
 	);
 

--- a/client/schema/service-details/VersionDetails.jsx
+++ b/client/schema/service-details/VersionDetails.jsx
@@ -9,6 +9,7 @@ import {
 	VersionHeader,
 	VersionHeaderTitle,
 	VersionHeaderTime,
+	VersionHeaderUrl
 } from '../styled';
 import CallMergeIcon from '@material-ui/icons/CallMerge';
 
@@ -41,6 +42,16 @@ const VersionDetails = () => {
 
 	const { id, addedTime, typeDefs, previousSchema, containers } = data.schema;
 	const addedTimestamp = new Date(addedTime);
+	const url = data.schema.service.url;
+
+	let urlInfo;
+	if (url) {
+		urlInfo = (
+			<VersionHeaderUrl>
+				Url{' '}{ url }
+			</VersionHeaderUrl>
+		);
+	}
 
 	const oldCode = previousSchema ? previousSchema.typeDefs : '';
 
@@ -72,6 +83,7 @@ const VersionDetails = () => {
 								timeZone: 'UTC',
 							})}
 						</VersionHeaderTime>
+						{urlInfo}
 					</div>
 					<ButtonGroup>
 						<DeactivateButton schema={data.schema} />

--- a/client/schema/styled.js
+++ b/client/schema/styled.js
@@ -27,6 +27,9 @@ export const VersionHeaderTitle = styled.h2`
 export const VersionHeaderTime = styled.div`
 	color: gray;
 `;
+export const VersionHeaderUrl = styled.div`
+	color: gray;
+`;
 
 export const SelectServiceGuide = styled.h1`
 	text-align: center;

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -53,6 +53,10 @@ export const SCHEMA_DETAILS = gql`
 			isActive
 			addedTime
 
+			service {
+				url
+			}
+
 			containerCount
 
 			containers {

--- a/examples/federated_service_a/index.js
+++ b/examples/federated_service_a/index.js
@@ -49,6 +49,7 @@ app.listen({ port: 6101 }, () => {
 				name: 'service_a', // service name
 				version: 'v1', //service version, like docker container hash. Use 'latest' for dev env
 				type_defs: typeDefs.toString(),
+				url: 'http://localhost:6101',
 			},
 		});
 		console.info('Schema registered successfully!');

--- a/examples/federated_service_b/index.js
+++ b/examples/federated_service_b/index.js
@@ -41,6 +41,7 @@ console.log('Running a GraphQL API server at http://localhost:6102/graphql');
 				name: 'service_b', // service name
 				version: 'v1', //service version, like docker container hash. Use 'latest' for dev env
 				type_defs: printSchema(schema),
+        url: 'http://localhost:6102',
 			},
 		});
 		console.info('Schema registered successfully!');

--- a/examples/gateway_service/poll-schema-registry.js
+++ b/examples/gateway_service/poll-schema-registry.js
@@ -2,50 +2,31 @@ const { get } = require('lodash');
 const request = require('request-promise-native');
 
 exports.getServiceListWithTypeDefs = async () => {
-	// make this list dynamic to update version on-the-fly depending on containers
-	const services = [
-		{
-			name: 'service_a',
-			version: 'v1', // use docker hash of the containers
-		},
 
-		{
-			name: 'service_b',
-			version: 'v1',
-		},
-	];
 	const serviceTypeDefinitions = await request({
 		baseUrl: 'http://localhost:6001',
 		method: 'POST',
-		url: '/schema/compose',
+		url: '/schema/latest',
 		json: true,
-		body: {
-			services,
-		},
 	});
 
 	return get(serviceTypeDefinitions, 'data', []).map((schema) => {
-		const service = services.find(
-			(service) => service.name === schema.name
-		);
 
-		if (!service) {
+		if (!schema.url) {
 			console.warn(
-				`Matching service not found for type definition "${schema.name}"`
+				`Service url not found for type definition "${schema.name}"`
 			);
 		} else {
 			console.log(
 				`Got ${schema.name} service schema with version ${schema.version}`
 			);
 		}
-
 		return {
 			name: schema.name,
-			url: `dynamic://${schema.name}`,
+			url: schema.url,
 			version: schema.version,
 			typeDefs: schema.type_defs,
 			typeDefsOriginal: schema.type_defs_original,
-			...(service ? service : {}),
 		};
 	});
 };

--- a/examples/gateway_service/remote-data-source.js
+++ b/examples/gateway_service/remote-data-source.js
@@ -10,16 +10,8 @@ class RemoteGraphQLDataSource {
 	}
 
 	async process({ request, context = {} }) {
-		// use service discovery (etcd, consul) to dynamically update addresses of services
-		let url;
-		switch (this.name) {
-			case 'service_a':
-				url = `http://localhost:6101/graphql`;
-				break;
-			case 'service_b':
-				url = `http://localhost:6102/graphql`;
-				break;
-		}
+
+		const url = `${this.url}/graphql`;
 
 		const headers = (request.http && request.http.headers) || new Headers();
 		headers.set('Content-Type', 'application/json');

--- a/migrations/20210522225999_add_service_url.sql
+++ b/migrations/20210522225999_add_service_url.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `services`
+    ADD `url` varchar(255) DEFAULT NULL
+    COMMENT 'Url for a specific service';


### PR DESCRIPTION
## Problem

Apollos managed federation eliminates the need for the gateway to manually define services or depend on yet-another external dependency (consul, etcd) for service discovery. Services can be instantiated using the offical cli ala 

```
rover subgraph publish my-graph@my-variant --name products --routing-url http://products-graphql.svc.cluster.local:4001/ --schema ./schema.graphql 
```

https://www.apollographql.com/docs/federation/managed-federation/setup/#3-modify-the-gateway-if-necessary

This PR allows the registry to emulate this fully-managed federation. 

When updating a schema users can now add an optional `url` parameter to `/schema/push`, which will update the service.url for the schema. This argument is returned as part of the services schema when running `/schema/latest` or `/schema/compose`. 


## Changes

- `/schema/push` has been modified to allow an optional `url` argument. 
- examples updated to reflect new service url discovery functionality 
