### PR TITLE
Fixing a bug with the Kafka ASYNC_SCHEMA_UPDATES environment variable evaluation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # IDEs
 .vscode
 .idea
+*.iml
 .atom-build.json
 .project
 coverage

--- a/app/config.js
+++ b/app/config.js
@@ -24,5 +24,9 @@ module.exports = {
 			port: process.env.KAFKA_BROKER_PORT || '9092',
 		},
 	},
-	asyncSchemaUpdates: Boolean(process.env.ASYNC_SCHEMA_UPDATES || 'false'),
+	asyncSchemaUpdates: booleanFor(process.env.ASYNC_SCHEMA_UPDATES),
 };
+
+function booleanFor(variable) {
+	return (variable || 'false').toLowerCase() === 'true';
+}


### PR DESCRIPTION
## Problem

There's a problem with the evaluation of the `ASYNC_SCHEMA_UPDATES` environment variable that toggles on/off usage of Kafka. The variable defaults to `'false'`, and `Boolean('false')` evaluates to true. So when the variable is not set, even when set explicitly to `'false'`, Kafka objects get initialized, and when you don't have Kafka running, it results in a startup error.