### PR TITLE
Adding a mechanism to turn off schema validation when retrieving schemas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ DB_HOST=my-db-host DB_PORT=6000 npm run migrate-db
 Unit tests use jest, coverage is quite low as most logic is in db or libraries.
 
 ```
-npm run test-unit
+npm run test
 ```
 
 Functional tests require docker, mostly blackbox type - real http requests are done against containers.

--- a/src/controller/schema.test.ts
+++ b/src/controller/schema.test.ts
@@ -1,0 +1,57 @@
+import schemaDB from '../database/schema';
+import { getAndValidateSchema } from './schema';
+import { connection } from '../database';
+import * as federation from '../helpers/federation';
+
+jest.mock('../database/schema');
+jest.mock('../helpers/federation');
+
+describe('controller/schema', () => {
+	it('getting schemas validates by default', async () => {
+		const serviceA = {
+			name: 'service-a',
+			version: '1.0',
+			url: 'http://service-a/graphql',
+			type_defs: 'type Query { me: String! }',
+		};
+
+		const serviceB = {
+			name: 'service-b',
+			version: '1.0',
+			url: 'http://service-b/graphql',
+			type_defs: 'type Query { hello: String! }',
+		};
+
+		schemaDB.getLastUpdatedForActiveServices = jest
+			.fn()
+			.mockResolvedValue([serviceA, serviceB]);
+
+		await getAndValidateSchema(connection);
+
+		expect(federation.composeAndValidateSchema).toHaveBeenCalled();
+	});
+
+	it('getting schemas does not validate if not requested', async () => {
+		const serviceA = {
+			name: 'service-a',
+			version: '1.0',
+			url: 'http://service-a/graphql',
+			type_defs: 'type Query { me: String! }',
+		};
+
+		const serviceB = {
+			name: 'service-b',
+			version: '1.0',
+			url: 'http://service-b/graphql',
+			type_defs: 'type Query { hello: String! }',
+		};
+
+		schemaDB.getLastUpdatedForActiveServices = jest
+			.fn()
+			.mockResolvedValue([serviceA, serviceB]);
+
+		await getAndValidateSchema(connection, false, false);
+
+		expect(federation.composeAndValidateSchema).not.toHaveBeenCalled();
+	});
+});

--- a/src/controller/schema.ts
+++ b/src/controller/schema.ts
@@ -7,7 +7,7 @@ import Knex from 'knex';
 
 import { logger } from '../logger';
 
-export async function getAndValidateSchema(trx: Knex, services = false) {
+export async function getAndValidateSchema(trx: Knex, services = false, validate = true) {
 	const schemas = services
 		? await schemaModel.getSchemaByServiceVersions({ trx, services })
 		: await schemaModel.getLastUpdatedForActiveServices({ trx });
@@ -19,7 +19,7 @@ export async function getAndValidateSchema(trx: Knex, services = false) {
 		}
 	);
 
-	if (schemas && schemas.length) {
+	if (validate && schemas && schemas.length) {
 		federationHelper.composeAndValidateSchema(schemas);
 	}
 

--- a/src/router/schema.ts
+++ b/src/router/schema.ts
@@ -11,7 +11,13 @@ import config from '../config';
 import * as kafka from '../kafka';
 
 export async function composeLatest(req, res) {
-	const schema = await getAndValidateSchema(connection);
+	const { validate } = Joi.attempt(
+		req.query,
+		Joi.object().keys({
+			validate: Joi.boolean().default(true).allow(''),
+		})
+	);
+	const schema = await getAndValidateSchema(connection, false, validate);
 
 	return res.json({
 		success: true,
@@ -36,8 +42,14 @@ export async function compose(req, res) {
 			})
 			.options({ stripUnknown: true })
 	);
+	const { validate } = Joi.attempt(
+		req.query,
+		Joi.object().keys({
+			validate: Joi.boolean().default(true).allow(''),
+		})
+	);
 
-	const schema = await getAndValidateSchema(connection, services);
+	const schema = await getAndValidateSchema(connection, services, validate);
 
 	return res.json({
 		success: true,

--- a/src/router/schema.ts
+++ b/src/router/schema.ts
@@ -11,13 +11,7 @@ import config from '../config';
 import * as kafka from '../kafka';
 
 export async function composeLatest(req, res) {
-	const { validate } = Joi.attempt(
-		req.query,
-		Joi.object().keys({
-			validate: Joi.boolean().default(true).allow(''),
-		})
-	);
-	const schema = await getAndValidateSchema(connection, false, validate);
+	const schema = await getAndValidateSchema(connection, false, false);
 
 	return res.json({
 		success: true,
@@ -42,14 +36,8 @@ export async function compose(req, res) {
 			})
 			.options({ stripUnknown: true })
 	);
-	const { validate } = Joi.attempt(
-		req.query,
-		Joi.object().keys({
-			validate: Joi.boolean().default(true).allow(''),
-		})
-	);
 
-	const schema = await getAndValidateSchema(connection, services, validate);
+	const schema = await getAndValidateSchema(connection, services);
 
 	return res.json({
 		success: true,


### PR DESCRIPTION
## Problem

Schema validation, more precisely the `composeAndValidate()` function from `@apollo/federation` is pretty slow. With many schemas in a schema registry instance, retrieving the latest schemas, or composing a set of schemas, becomes pretty slow. Since schemas get validated when publishing to the registry, validating on get is not absolutely necessary.

## Changes

- In order to speed up schema retrieval, I introduced a mechanism to avoid validating on get by passing a query parameter. The default behaviour is preserved, meaning schemas get validated on get. Only when the `validate` query parameter is passed as `false` will schema validation be skipped. Not executing validations on get results in a > 10x improvement on the API response time.

## Testing

Added a unit test for the `getAndValidateSchema()` function in the `controller/schema.ts` file.
