### PR TITLE
add logs tab

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,6 @@
 	],
 	"extends": [
 		"eslint:recommended",
-		"pipedrive",
 		"plugin:@typescript-eslint/eslint-recommended",
 		"plugin:prettier/recommended",
 		"plugin:@typescript-eslint/recommended"
@@ -28,7 +27,6 @@
 				"plugin:@typescript-eslint/recommended",
 				"plugin:react/recommended",
 				"plugin:react/jsx-runtime",
-				"pipedrive",
 				"plugin:prettier/recommended"
 			],
 			"env": {
@@ -47,7 +45,6 @@
 				"eslint:recommended",
 				"plugin:react/recommended",
 				"plugin:react/jsx-runtime",
-				"pipedrive",
 				"plugin:prettier/recommended"
 			],
 			"settings": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
 	},
 	"rules": {
 		"@typescript-eslint/ban-ts-comment": "warn",
-		"camelcase": "warn",
+		"camelcase": "off",
 		"no-unused-vars": "off",
 		"@typescript-eslint/no-unused-vars": ["warn"]
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Types of changes:
 ## [Unreleased]
 
 ## [5.2.0] 2022-10-08
+
 ### Added
+
 - logs tab added
 - add winston-redis-stream dependency for logs to stream to redis
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+## [5.2.0] 2022-10-08
+### Added
+- logs tab added
+- add winston-redis-stream dependency for logs to stream to redis
+
 ## [5.1.1] 2022-10-07
 
 ### Changed
+
 - fix re-opening pages/navigation on refresh
 
 ## [5.1.0] 2022-10-06

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ erDiagram
 
 ```
 
-
 ## Configuration
 
 We use environment variables for configuration.
@@ -205,7 +204,6 @@ The following are the different environment variables that are looked up that al
 For development we rely on docker network and use hostnames from `docker-compose.yml`.
 Node service uses to connect to mysql & redis and change it if you install it with own setup.
 For dynamic service discovery (if you need multiple hosts for scaling), override `app/config.js` and `diplomat.js`
-
 
 ## Use cases / FAQ
 

--- a/client/__mocks__/fileMock.js
+++ b/client/__mocks__/fileMock.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line no-undef
 module.exports = 'test-file-stub';

--- a/client/__mocks__/styleMock.js
+++ b/client/__mocks__/styleMock.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line no-undef
 module.exports = {};

--- a/client/clients/index.jsx
+++ b/client/clients/index.jsx
@@ -1,4 +1,4 @@
-//eslint-disable-next-line
+// eslint-disable-next-line
 import React, { useState } from 'react';
 import { HashRouter as Router } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
@@ -10,6 +10,7 @@ import { CLIENTS_LIST } from '../utils/queries';
 import { ColumnPanel } from '../components/styled';
 import ClientVersions from './versions';
 import ClientPersistedQueries from './clientPersistedQueries';
+import Info from '../components/Info';
 
 export default function Clients() {
 	const { loading, data } = useQuery(CLIENTS_LIST);
@@ -22,7 +23,12 @@ export default function Clients() {
 	}
 
 	if (!data || data.clients.length === 0) {
-		return <div style={{ padding: '10px' }}>No clients found</div>;
+		return (
+			<Info>
+				No clients found. Use gql-schema-registry-worker to process
+				queries from KAFKA_QUERIES_TOPIC
+			</Info>
+		);
 	}
 
 	const clients = data.clients.map((client) => {

--- a/client/components/Info.jsx
+++ b/client/components/Info.jsx
@@ -1,0 +1,16 @@
+// eslint-disable-next-line no-unused-vars
+import React from 'react';
+
+export default function Info({ children }) {
+	return (
+		<div
+			style={{
+				padding: '10px 15px',
+				color: 'white',
+				backgroundColor: '#3279e2',
+			}}
+		>
+			{children}
+		</div>
+	);
+}

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -8,6 +8,7 @@ import Clients from '../clients';
 
 import ServicesTab from '../schema/Tab';
 import PersistedQueriesTab from '../persisted-queries/Tab';
+import Logs from '../logs';
 
 const UITabs = [
 	{
@@ -24,6 +25,11 @@ const UITabs = [
 		Title: <PersistedQueriesTab />,
 		href: '/persisted-queries',
 		component: PersistedQueries,
+	},
+	{
+		Title: <span>Logs</span>,
+		href: '/logs',
+		component: Logs,
 	},
 ];
 

--- a/client/logs/index.jsx
+++ b/client/logs/index.jsx
@@ -1,0 +1,60 @@
+// eslint-disable-next-line no-unused-vars
+import React from 'react';
+import { useQuery } from '@apollo/client';
+
+import SpinnerCenter from '../components/SpinnerCenter';
+
+import { LOGS } from '../utils/queries';
+import Info from '../components/Info';
+
+import { format } from 'date-fns';
+
+export default function PersistedQueries() {
+	const { loading, data } = useQuery(LOGS);
+
+	if (loading) {
+		return <SpinnerCenter />;
+	}
+
+	if (!data || !data.logs.length) {
+		return <Info>No Logs yet</Info>;
+	}
+
+	return (
+		<div>
+			<Info>
+				You can see last schema-registry logs. Useful in case of
+				validation errors
+			</Info>
+
+			<table>
+				{data.logs.map((row, i) => (
+					<tr key={i}>
+						<td
+							style={{
+								borderRight: '1px solid gray',
+								padding: '0 10px',
+							}}
+						>
+							{format(new Date(row.timestamp), 'd MMMM / HH:mm', {
+								timeZone: 'UTC',
+							})}
+						</td>
+						<td>{row.level.indexOf('error') > 0 ? '🔴' : 'ℹ️'} </td>
+						<td>
+							{typeof row.message === 'string' ? row.message : ''}
+							{typeof row.message === 'object' &&
+								row.message.map((row, j) => {
+									return (
+										<div key={j}>
+											{row.message}({row.extensions.code})
+										</div>
+									);
+								})}
+						</td>
+					</tr>
+				))}
+			</table>
+		</div>
+	);
+}

--- a/client/persisted-queries/index.jsx
+++ b/client/persisted-queries/index.jsx
@@ -1,9 +1,12 @@
+// eslint-disable-next-line no-unused-vars
+import React from 'react';
 import { useQuery } from '@apollo/client';
 
 import SpinnerCenter from '../components/SpinnerCenter';
 import PersistedQuery from './PersistedQuery';
 
 import { PERSISTED_QUERIES } from '../utils/queries';
+import Info from '../components/Info';
 
 export default function PersistedQueries() {
 	const { loading, data } = useQuery(PERSISTED_QUERIES);
@@ -13,7 +16,12 @@ export default function PersistedQueries() {
 	}
 
 	if (!data || !data.persistedQueries.length) {
-		return <div style={{ padding: 10 }}>No persisted queries found</div>;
+		return (
+			<Info>
+				No persisted queries found. Integrate gateway to publish
+				persisted query to schema-registry API
+			</Info>
+		);
 	}
 
 	return (

--- a/client/schema/service-list/index.jsx
+++ b/client/schema/service-list/index.jsx
@@ -7,6 +7,7 @@ import { useRouteMatch, useHistory } from 'react-router-dom';
 
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import Info from '../../components/Info';
 
 const ServiceList = () => {
 	const { data } = useQuery(SERVICES_LIST);
@@ -14,18 +15,19 @@ const ServiceList = () => {
 	if (!data || !data.services || data.services.length === 0) {
 		return (
 			<ServiceListColumnEmpty>
-				<p>No federated services found</p>
-				<p>
+				<Info>
+					No federated services found
+					<br />
 					Use{' '}
 					<a
 						href={
-							'https://github.com/pipedrive/graphql-schema-registry#post-schemapush'
+							'https://github.com/pipedrive/graphql-schema-registry#-post-schemapush'
 						}
 					>
 						POST /schema/push
 					</a>{' '}
 					to add one
-				</p>
+				</Info>
 			</ServiceListColumnEmpty>
 		);
 	}

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -121,3 +121,9 @@ export const CLIENT_VERSION_PERSISTED_QUERIES = gql`
 		}
 	}
 `;
+
+export const LOGS = gql`
+	query getLogs {
+		logs
+	}
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql-schema-registry",
-  "version": "5.0.0",
+  "version": "5.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql-schema-registry",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.5.8",
@@ -36,7 +36,8 @@
         "redlock": "5.0.0-beta.2",
         "rumble-charts": "3.1.2",
         "styled-components": "5.3.3",
-        "winston": "3.7.2"
+        "winston": "3.7.2",
+        "winston-redis-stream": "0.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -68,7 +69,6 @@
         "css-loader": "^3.4.0",
         "css-minimizer-webpack-plugin": "^3.4.1",
         "eslint": "8.19.0",
-        "eslint-config-pipedrive": "13.0.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-react": "^7.29.4",
@@ -80,7 +80,6 @@
         "k6": "^0.0.0",
         "mini-css-extract-plugin": "^2.6.0",
         "morgan": "^1.9.1",
-        "node-mocks-http": "1.11.0",
         "prettier": "2.7.1",
         "react-refresh": "^0.13.0",
         "request": "^2.88.0",
@@ -4234,13 +4233,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -5417,25 +5409,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
@@ -5849,13 +5822,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "optional": true,
-      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -7881,16 +7847,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-config-pipedrive": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-pipedrive/-/eslint-config-pipedrive-13.0.0.tgz",
-      "integrity": "sha512-c7yOvgRUz2OoSRElKlRNEEWWy4pc4WjPBRwPBqHyDbx29XaDy8/GKbqaDO7tm1QcqamqHmahg6ToUX1C08qEQA==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=7",
-        "eslint-plugin-import": "^2.25.4"
-      }
-    },
     "node_modules/eslint-config-prettier": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
@@ -7901,179 +7857,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/eslint-module-utils/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -8606,13 +8389,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -10171,17 +9947,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/ioredis/node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -10665,13 +10430,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/jest": {
       "version": "27.5.1",
@@ -12957,6 +12715,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -13483,36 +13246,6 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
-    "node_modules/node-mocks-http": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.11.0.tgz",
-      "integrity": "sha512-jS/WzSOcKbOeGrcgKbenZeNhxUNnP36Yw11+hL4TTxQXErGfqYZ+MaYNNvhaTiGIJlzNSqgQkk9j8dSu1YWSuw==",
-      "dev": true,
-      "dependencies": {
-        "accepts": "^1.3.7",
-        "content-disposition": "^0.5.3",
-        "depd": "^1.1.0",
-        "fresh": "^0.5.2",
-        "merge-descriptors": "^1.0.1",
-        "methods": "^1.1.2",
-        "mime": "^1.3.4",
-        "parseurl": "^1.3.3",
-        "range-parser": "^1.2.0",
-        "type-is": "^1.6.18"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/node-mocks-http/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
@@ -13811,6 +13544,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/p-try": {
@@ -15041,10 +14782,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
       "engines": {
         "node": ">=4"
       }
@@ -16101,34 +15858,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
-      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.10.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -16651,32 +16380,6 @@
         "@types/strip-json-comments": "0.0.30",
         "strip-bom": "^3.0.0",
         "strip-json-comments": "^2.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/tsconfig/node_modules/strip-json-comments": {
@@ -17400,6 +17103,69 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/winston-redis-stream": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/winston-redis-stream/-/winston-redis-stream-0.0.3.tgz",
+      "integrity": "sha512-I6I9T4UE2LOm8FDpOkb3flCOy9JVkYzFFwU9XFT/8CPWBzLiwO6hl5gD6n41QuKXO6H11tCeg+fm2VPBgghLNQ==",
+      "dependencies": {
+        "async": "^3.1.0",
+        "ioredis": "^4.14.1",
+        "lodash": "^4.6.1",
+        "winston-transport": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8.11.x"
+      },
+      "peerDependencies": {
+        "winston": "^3.0.0"
+      }
+    },
+    "node_modules/winston-redis-stream/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/winston-redis-stream/node_modules/ioredis": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+      "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+      "dependencies": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/winston-redis-stream/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/winston-transport": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
@@ -17520,7 +17286,7 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -20680,13 +20446,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "peer": true
-    },
     "@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -21591,19 +21350,6 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
-    "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
     "array.prototype.flatmap": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
@@ -21921,13 +21667,6 @@
         "babel-plugin-jest-hoist": "^27.5.1",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "optional": true,
-      "peer": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -23643,168 +23382,12 @@
         }
       }
     },
-    "eslint-config-pipedrive": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-pipedrive/-/eslint-config-pipedrive-13.0.0.tgz",
-      "integrity": "sha512-c7yOvgRUz2OoSRElKlRNEEWWy4pc4WjPBRwPBqHyDbx29XaDy8/GKbqaDO7tm1QcqamqHmahg6ToUX1C08qEQA==",
-      "dev": true,
-      "requires": {}
-    },
     "eslint-config-prettier": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
       "dev": true,
       "requires": {}
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true,
-          "peer": true
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-          "dev": true,
-          "peer": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
-      }
     },
     "eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -24049,13 +23632,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "optional": true,
-      "peer": true
     },
     "events": {
       "version": "3.3.0",
@@ -25205,14 +24781,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "redis-parser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-          "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-          "requires": {
-            "redis-errors": "^1.0.0"
-          }
         }
       }
     },
@@ -25554,13 +25122,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "optional": true,
-      "peer": true
     },
     "jest": {
       "version": "27.5.1",
@@ -27284,6 +26845,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -27714,32 +27280,6 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
-    "node-mocks-http": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.11.0.tgz",
-      "integrity": "sha512-jS/WzSOcKbOeGrcgKbenZeNhxUNnP36Yw11+hL4TTxQXErGfqYZ+MaYNNvhaTiGIJlzNSqgQkk9j8dSu1YWSuw==",
-      "dev": true,
-      "requires": {
-        "accepts": "^1.3.7",
-        "content-disposition": "^0.5.3",
-        "depd": "^1.1.0",
-        "fresh": "^0.5.2",
-        "merge-descriptors": "^1.0.1",
-        "methods": "^1.1.2",
-        "mime": "^1.3.4",
-        "parseurl": "^1.3.3",
-        "range-parser": "^1.2.0",
-        "type-is": "^1.6.18"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-          "dev": true
-        }
-      }
-    },
     "node-releases": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
@@ -27952,6 +27492,11 @@
       "requires": {
         "p-limit": "^3.0.2"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-try": {
       "version": "2.2.0",
@@ -28811,10 +28356,23 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
     "redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "redlock": {
       "version": "5.0.0-beta.2",
@@ -29595,29 +29153,6 @@
         "postcss-selector-parser": "^6.0.4"
       }
     },
-    "subscriptions-transport-ws": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
-      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -29975,31 +29510,6 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
-        }
-      }
-    },
-    "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
         }
       }
     },
@@ -30556,6 +30066,50 @@
         }
       }
     },
+    "winston-redis-stream": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/winston-redis-stream/-/winston-redis-stream-0.0.3.tgz",
+      "integrity": "sha512-I6I9T4UE2LOm8FDpOkb3flCOy9JVkYzFFwU9XFT/8CPWBzLiwO6hl5gD6n41QuKXO6H11tCeg+fm2VPBgghLNQ==",
+      "requires": {
+        "async": "^3.1.0",
+        "ioredis": "^4.14.1",
+        "lodash": "^4.6.1",
+        "winston-transport": "^4.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ioredis": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+          "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+          "requires": {
+            "cluster-key-slot": "^1.1.0",
+            "debug": "^4.3.1",
+            "denque": "^1.1.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.isarguments": "^3.1.0",
+            "p-map": "^2.1.0",
+            "redis-commands": "1.7.0",
+            "redis-errors": "^1.2.0",
+            "redis-parser": "^3.0.0",
+            "standard-as-callback": "^2.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "winston-transport": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
@@ -30643,7 +30197,7 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "devOptional": true,
+      "dev": true,
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-registry",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Graphql schema registry",
   "main": "app/schema-registry.js",
   "engines": {
@@ -80,7 +80,8 @@
     "redlock": "5.0.0-beta.2",
     "rumble-charts": "3.1.2",
     "styled-components": "5.3.3",
-    "winston": "3.7.2"
+    "winston": "3.7.2",
+    "winston-redis-stream": "0.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
@@ -112,7 +113,6 @@
     "css-loader": "^3.4.0",
     "css-minimizer-webpack-plugin": "^3.4.1",
     "eslint": "8.19.0",
-    "eslint-config-pipedrive": "13.0.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "^7.29.4",

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,6 +1,8 @@
 import { isUndefined } from 'lodash';
 import { parse } from 'graphql';
 
+import { logger } from '../logger';
+
 import { deactivateSchema, activateSchema } from '../controller/schema';
 import config from '../config';
 import { connection } from '../database';
@@ -54,6 +56,31 @@ export default {
 		persistedQueriesCount: async () => await PersistedQueriesModel.count(),
 
 		clients: async () => await clientsModel.getClients(),
+		logs: async () => {
+			const logs = await new Promise((resolve, reject) =>
+				logger.query(
+					{
+						// @ts-ignore
+						from: new Date() - 24 * 60 * 60 * 1000,
+						until: new Date(),
+						limit: 100,
+						start: 0,
+						order: 'desc',
+						fields: ['message', 'level', 'timestamp'],
+					},
+					function (err, results) {
+						if (err) {
+							reject(err);
+						}
+
+						resolve(results);
+					}
+				)
+			);
+
+			// @ts-ignore
+			return logs?.redis;
+		},
 	},
 	Mutation: {
 		deactivateSchema: async (parent, { id }) => {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -4,6 +4,7 @@ export default gql`
 	scalar Time
 	scalar Date
 	scalar DateTime
+	scalar JSON
 
 	type Query {
 		services(limit: Int, offset: Int): [Service]
@@ -27,6 +28,7 @@ export default gql`
 
 		clients: [Client]
 		clientVersions(since: DateTime): [ClientVersion]
+		logs: JSON
 	}
 
 	type Mutation {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { logger } from './logger';
 const app = express();
 
 let server = null;
+let shutdownTry = 0;
 
 function monitorConnections() {
 	if (!server) {
@@ -22,8 +23,9 @@ function monitorConnections() {
 
 		logger.info(`Process shutting down with ${count} open connections\n`);
 
-		if (count > 0) {
-			setTimeout(() => monitorConnections(), 2000);
+		if (count > 0 && shutdownTry < 5) {
+			shutdownTry++;
+			setTimeout(() => monitorConnections(), 1000);
 		}
 	});
 }

--- a/src/kafka/index.ts
+++ b/src/kafka/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Consumer, Kafka } from 'kafkajs';
 import diplomat from '../diplomat';
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,16 +1,21 @@
 import { createLogger, transports, format } from 'winston';
 import RedisTransport from 'winston-redis-stream';
 
-export const logger = createLogger({
-	level: process.env.LOG_LEVEL || 'info',
-	transports: [
-		new transports.Console(),
+const logTransports = [new transports.Console()];
+
+if (process.env.REDIS_HOST) {
+	logTransports.push(
 		new RedisTransport({
 			host: process.env.REDIS_HOST,
 			port: process.env.REDIS_PORT,
 			channel: 'logs',
-		}),
-	],
+		})
+	);
+}
+
+export const logger = createLogger({
+	level: process.env.LOG_LEVEL || 'info',
+	transports: logTransports,
 	format:
 		process.env.LOG_TYPE === 'json'
 			? buildJsonFormat()

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,16 @@
 import { createLogger, transports, format } from 'winston';
+import RedisTransport from 'winston-redis-stream';
 
 export const logger = createLogger({
 	level: process.env.LOG_LEVEL || 'info',
-	transports: [new transports.Console()],
+	transports: [
+		new transports.Console(),
+		new RedisTransport({
+			host: process.env.REDIS_HOST,
+			port: process.env.REDIS_PORT,
+			channel: 'logs',
+		}),
+	],
 	format:
 		process.env.LOG_TYPE === 'json'
 			? buildJsonFormat()

--- a/src/redis/index.ts
+++ b/src/redis/index.ts
@@ -35,10 +35,7 @@ async function resolveInstance(service) {
 	}
 }
 
-async function initRedis(
-	redisServiceName = process.env.REDIS_SCHEMA_REGISTRY ||
-		'gql-schema-registry-redis'
-) {
+async function initRedis() {
 	try {
 		// @ts-ignore
 		redis = new Redis({
@@ -53,17 +50,16 @@ async function initRedis(
 			logger.warn('Redis reconnect triggered, re-discovering');
 			Object.assign(
 				redis.options || {},
-				await resolveInstance(redisServiceName)
+				await resolveInstance('gql-schema-registry-redis')
 			);
 		});
 
-		redis.on('ready', () =>
-			logger.info(`Redis connection to ${redisServiceName} ready`)
-		);
+		redis.on('ready', () => logger.info(`Redis connection to redis ready`));
+		redis.on('error', (e) => logger.error(`Redis error`, e));
 
 		Object.assign(
 			redis.options || {},
-			await resolveInstance(redisServiceName)
+			await resolveInstance('gql-schema-registry-redis')
 		);
 
 		await redis.connect();

--- a/src/redis/redis.itest.ts
+++ b/src/redis/redis.itest.ts
@@ -25,8 +25,7 @@ describe('redis', () => {
 
 		it('get should return null if redis is not initialized', async () => {
 			// no prior initRedis() here
-			const { initRedis, get, disconnect } = (await import('./index'))
-				.default;
+			const { get } = (await import('./index')).default;
 			const result = await get('aaa');
 
 			expect(result).toEqual(null);

--- a/src/router/schema.itest.ts
+++ b/src/router/schema.itest.ts
@@ -1,4 +1,4 @@
-import { composeLatest, compose, push } from '../router/schema';
+import { composeLatest, push } from '../router/schema';
 import { cleanTables } from '../../test/integration/database';
 
 describe('app/controller/schema', () => {
@@ -136,7 +136,7 @@ describe('app/controller/schema', () => {
 				};
 
 				try {
-					const result = await push(req, res);
+					await push(req, res);
 					expect(false).toEqual(true);
 				} catch (e) {
 					expect(e.message).toEqual(
@@ -156,7 +156,7 @@ describe('app/controller/schema', () => {
 				};
 
 				try {
-					const result = await push(req, res);
+					await push(req, res);
 					expect(false).toEqual(true);
 				} catch (e) {
 					expect(e.message).toEqual(
@@ -176,7 +176,7 @@ describe('app/controller/schema', () => {
 				};
 
 				try {
-					const result = await push(req, res);
+					await push(req, res);
 					expect(false).toEqual(true);
 				} catch (e) {
 					expect(e.message).toEqual(
@@ -221,7 +221,7 @@ describe('app/controller/schema', () => {
 
 			it('fails if type B with @extends has no base service', async () => {
 				try {
-					const result = await push(
+					await push(
 						{
 							body: {
 								name: 'service_a',

--- a/src/setupDev.ts
+++ b/src/setupDev.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Application } from 'express';
 import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';

--- a/src/worker/analyzeQueries/index.ts
+++ b/src/worker/analyzeQueries/index.ts
@@ -1,5 +1,6 @@
 import { get, isNil } from 'lodash';
 import { TypeInfo } from 'graphql';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Knex } from 'knex';
 
 import { logger } from '../../logger';


### PR DESCRIPTION
## Problem
Sometimes when schema registration fails, its hard to trace why. 
You need to either check schema-registry logs, or you need to debug endpoint response output on client side
This adds Logs UI which shows all logs that schema-registry does via regular `logger.error()` functions, just uses redis as a temporary storage

## Changes
- add logs tab (reads from redis)
- add info component
- add winston-redis-stream for temporary storage for logs

<img width="1061" alt="Screenshot 2022-10-08 at 02 22 57" src="https://user-images.githubusercontent.com/445122/194675525-2176eb9d-6578-4ef9-994a-acedf694dc3b.png">
