### PR TITLE
Schema for uniqueness comparison improvement with hashing -> schema.UUID

### DIFF
--- a/.dora.json
+++ b/.dora.json
@@ -1,0 +1,5 @@
+{
+  "pipedriveBaseImage": {
+    "active": false
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Types of changes:
 ## [Unreleased]
 
 ## [5.3.0] 2022-10-11
+
 ### Changed
+
 - added global search input in menu
 - removed per-version search as redundant
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,34 @@ Types of changes:
 
 ## [Unreleased]
 
+## [5.4.0] 2022-10-27
+### Changed
+- Add schema normalization (re-formatting) - this should get rid of extra tabbing & spacing when services register their schemas inconsistently
+- Fix knex migration generation from commandline (`npm run new-db-migration my-new-migration`)
+- Improve migration scripts to support JS migrations. Possibly somewhat breaking change for organizations that relied only on .sql files
+- Migrate schemas to now include UUID (js migration). If your organization didn't expect/run js migrations, you will have empty UUIDs, but follow-up schema registrations should have it in new schemas, so not a big deal, just may be a bit confusing in the UI
+- Do not delete duplicate schemas as its a bit dangerous. You may have had duplicate schemas before. We could have deleted them, but its a risky operation.
+
+If you need to clean them up, here is a script:
+```sql
+UPDATE `container_schema` t3
+  INNER JOIN `schema` t1
+  INNER JOIN `schema` t2
+  SET t3.schema_id = t1.id
+  WHERE t1.UUID IS NOT null
+    AND t1.id < t2.id
+    AND t1.UUID = t2.UUID
+    AND t3.schema_id = t2.id;
+
+DELETE t2
+  FROM `schema` t1
+  INNER JOIN `schema` t2
+  WHERE
+    t2.UUID IS NOT null AND
+    t1.id < t2.id AND
+    t1.UUID = t2.UUID;
+```
+
 ## [5.3.0] 2022-10-11
 
 ### Changed
@@ -357,7 +385,11 @@ DELETE /schema/:schemaId
 - Frontend app
 - Examples of gateway + 2 federated services
 
-[unreleased]: https://github.com/pipedrive/graphql-schema-registry/compare/v5.0.0...HEAD
+[unreleased]: https://github.com/pipedrive/graphql-schema-registry/compare/v5.4.0...HEAD
+[5.4.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v5.3.0...v5.4.0
+[5.3.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v5.2.0...v5.3.0
+[5.2.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v5.1.0...v5.2.0
+[5.1.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v3.5.0...v4.0.0
 [3.5.0]: https://github.com/pipedrive/graphql-schema-registry/compare/v3.4.0...v3.5.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,12 @@ Versions that are currently supported with security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | 5.x.x   | :white_check_mark: |
-| 4.x.x   | :x: |
+| 4.x.x   | :x:                |
 
 ## Reporting a Vulnerability
+
 To report a vulnerability (in order of discretion)
+
 - Contact via email artjom.kurapov@pipedrive.com
 - Contact via [slack](http://gql-schema-registry.slack.com/)
 - Report github issue

--- a/client/schema/service-details/VersionDetails.jsx
+++ b/client/schema/service-details/VersionDetails.jsx
@@ -46,7 +46,8 @@ export default function VersionDetails() {
 		return null;
 	}
 
-	const { id, addedTime, typeDefs, previousSchema, containers } = data.schema;
+	const { UUID, addedTime, typeDefs, previousSchema, containers } =
+		data.schema;
 	const addedTimestamp = new Date(addedTime);
 	const url = data.schema.service.url;
 
@@ -109,7 +110,7 @@ export default function VersionDetails() {
 				<VersionHeader>
 					<div>
 						<VersionHeaderTitle noMargin>
-							Schema #{id}
+							Schema {UUID}
 						</VersionHeaderTitle>
 						<VersionHeaderTime>
 							Added{' '}

--- a/client/schema/service-details/VersionsList.jsx
+++ b/client/schema/service-details/VersionsList.jsx
@@ -46,15 +46,15 @@ const VersionsList = ({ service }) => {
 						<EntryGrid>
 							<div>
 								<FlexRow>
-									<VersionTag>#{schema.id}</VersionTag>
-									<VersionCharDelta
-										selected={selectedSchema === schema.id}
-										schema={schema}
-									/>
+									<VersionTag>{schema.UUID}</VersionTag>
 								</FlexRow>
 								<VersionRow
 									selected={selectedSchema === schema.id}
 								>
+									<VersionCharDelta
+										selected={selectedSchema === schema.id}
+										schema={schema}
+									/>
 									<span>
 										added{' '}
 										{formatDistance(date, today, {

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -37,6 +37,7 @@ export const SERVICE_SCHEMAS = gql`
 
 			schemas(limit: 100) {
 				id
+				UUID
 				isActive
 				addedTime
 				typeDefs
@@ -55,6 +56,7 @@ export const SCHEMA_DETAILS = gql`
 	query getSchema($schemaId: Int!) {
 		schema(id: $schemaId) {
 			id
+			UUID
 			typeDefs
 			isActive
 			addedTime

--- a/knexfile.js
+++ b/knexfile.js
@@ -4,7 +4,7 @@ const CustomSqlMigrationSource = require('./app/database/sql-migration-source');
 const DB_SCHEMA_REGISTRY =
 	process.env.DB_SCHEMA_REGISTRY || 'gql-schema-registry-db';
 const { client, host, port, username, secret, name } =
-	diplomat.getServiceInstance(DB_SCHEMA_REGISTRY);
+	diplomat.default.getServiceInstance(DB_SCHEMA_REGISTRY);
 
 module.exports = {
 	client: client,
@@ -19,7 +19,7 @@ module.exports = {
 	migrations: {
 		//Required to prevent Knex from complaining that the original js based migrations are not found by CustomSqlMigrationSource
 		disableMigrationsListValidation: true,
-		migrationSource: new CustomSqlMigrationSource('./migrations'),
+		migrationSource: new CustomSqlMigrationSource.default('./migrations'),
 		//Required for generating new migrations
 		extension: 'sql',
 	},

--- a/migrations/20221024100701_add-UUID.sql
+++ b/migrations/20221024100701_add-UUID.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `schema`
+    ADD `UUID` VARCHAR(64) NULL DEFAULT NULL COMMENT 'used in uniqueness checks' AFTER `id`;

--- a/migrations/20221024104924_fill-UUID-with-js.js
+++ b/migrations/20221024104924_fill-UUID-with-js.js
@@ -1,0 +1,12 @@
+const schemaModel = require('../app/database/schema');
+
+module.exports.up = async function (knex) {
+	try {
+		await schemaModel.default.addUUIDToAllSchemas(knex);
+	} catch (e) {
+		// eslint-disable-next-line
+		console.error(e);
+	}
+};
+
+module.exports.down = async function () {};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build-frontend": "webpack --node-env production --bail --config webpack.config.js",
     "docker-compose-validate": "docker-comply compose --file ./docker-compose.deploy.yml",
     "migrate-db": "knex migrate:latest",
-    "new-db-migration": "knex migrate:make --stub ./migrations/sql.stub rename_me",
+    "new-db-migration": "knex migrate:make --stub ./migrations/sql.stub",
     "list-db-migrations": "knex migrate:list",
     "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx client src",
     "lint:fix": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx client src --fix"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-registry",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Graphql schema registry",
   "main": "app/schema-registry.js",
   "engines": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export default {
 
 	serviceDiscovery: {
 		'gql-schema-registry-db': {
+			client: 'mysql2', // needed for knex migrate:make to not use sqlite3
 			host: process.env.DB_HOST || 'gql-schema-registry-db',
 			port: process.env.DB_PORT || '3306',
 			username: process.env.DB_USERNAME || 'root',

--- a/src/database/schema.itest.ts
+++ b/src/database/schema.itest.ts
@@ -1,0 +1,75 @@
+import schemaModel from './schema';
+import knex from '../../test/integration/database';
+
+describe('app/database/schema', () => {
+	beforeEach(async () => {
+		await knex.cleanTables();
+	});
+
+	it('listMigrateableSchemas - lists only schemas without UUID', async () => {
+		await knex('services').insert({
+			id: 1,
+			name: 'test-service',
+		});
+
+		await knex('schema').insert({
+			service_id: 1,
+			type_defs: `type UserA1 { name: String }`,
+			cost_map: '{}',
+			allow_map: '{}',
+		});
+
+		await knex('schema').insert({
+			service_id: 1,
+			type_defs: `type UserA2 { name: String }`,
+			cost_map: '{}',
+			allow_map: '{}',
+			UUID: 'asd',
+		});
+
+		const result = await schemaModel.listMigrateableSchemas(knex);
+
+		expect(result.length).toEqual(1);
+
+		expect(result[0]).toMatchObject({
+			type_defs: 'type UserA1 { name: String }',
+		});
+	});
+
+	it('addUUIDToAllEntities', async () => {
+		await knex('services').insert({
+			id: 1,
+			name: 'test-service',
+		});
+
+		await knex('schema').insert({
+			service_id: 1,
+			type_defs: `type UserA1 { name: String }`,
+			cost_map: '{}',
+			allow_map: '{}',
+		});
+
+		await knex('schema').insert({
+			service_id: 1,
+			type_defs: `type UserA2 { name: String }`,
+			cost_map: '{}',
+			allow_map: '{}',
+			UUID: 'asd',
+		});
+
+		await knex('schema').insert({
+			service_id: 1,
+			type_defs: `type UserA3 { name: String }`,
+			cost_map: '{}',
+			allow_map: '{}',
+		});
+
+		const result = await schemaModel.listMigrateableSchemas(knex);
+		expect(result.length).toEqual(2);
+
+		await schemaModel.addUUIDToAllSchemas(knex, 1);
+
+		const result2 = await schemaModel.listMigrateableSchemas(knex);
+		expect(result2.length).toEqual(0);
+	});
+});

--- a/src/database/schema.itest.ts
+++ b/src/database/schema.itest.ts
@@ -1,9 +1,9 @@
 import schemaModel from './schema';
-import knex from '../../test/integration/database';
+import knex, { cleanTables } from '../../test/integration/database';
 
 describe('app/database/schema', () => {
 	beforeEach(async () => {
-		await knex.cleanTables();
+		await cleanTables();
 	});
 
 	it('listMigrateableSchemas - lists only schemas without UUID', async () => {

--- a/src/database/schema.itest.ts
+++ b/src/database/schema.itest.ts
@@ -15,15 +15,11 @@ describe('app/database/schema', () => {
 		await knex('schema').insert({
 			service_id: 1,
 			type_defs: `type UserA1 { name: String }`,
-			cost_map: '{}',
-			allow_map: '{}',
 		});
 
 		await knex('schema').insert({
 			service_id: 1,
 			type_defs: `type UserA2 { name: String }`,
-			cost_map: '{}',
-			allow_map: '{}',
 			UUID: 'asd',
 		});
 
@@ -45,23 +41,17 @@ describe('app/database/schema', () => {
 		await knex('schema').insert({
 			service_id: 1,
 			type_defs: `type UserA1 { name: String }`,
-			cost_map: '{}',
-			allow_map: '{}',
 		});
 
 		await knex('schema').insert({
 			service_id: 1,
 			type_defs: `type UserA2 { name: String }`,
-			cost_map: '{}',
-			allow_map: '{}',
 			UUID: 'asd',
 		});
 
 		await knex('schema').insert({
 			service_id: 1,
 			type_defs: `type UserA3 { name: String }`,
-			cost_map: '{}',
-			allow_map: '{}',
 		});
 
 		const result = await schemaModel.listMigrateableSchemas(knex);

--- a/src/database/sql-migration-source.test.ts
+++ b/src/database/sql-migration-source.test.ts
@@ -9,16 +9,15 @@ describe('app/database/sql-migration-source.js', () => {
 
 		const migrations = await source.getMigrations();
 
-		assert.lengthOf(migrations, 2);
+		assert.lengthOf(migrations, 3);
 		assert.includeDeepOrderedMembers(
 			migrations,
-			[{ file: '00_test_migr1.sql' }, { file: '01_test_migr2.sql' }],
+			[
+				{ file: '00_test_migr1.sql' },
+				{ file: '01_test_migr2.sql' },
+				{ file: '02_test_migr3.js' },
+			],
 			'sql migrations should be sorted'
-		);
-		assert.notIncludeDeepMembers(
-			migrations,
-			[{ file: '02_test_migr3.js' }],
-			'js based migrations should not be returned'
 		);
 	});
 

--- a/src/database/sql-migration-source.ts
+++ b/src/database/sql-migration-source.ts
@@ -16,7 +16,7 @@ class CustomSqlMigrationSource implements Knex.MigrationSource<any> {
 		);
 		const files = fs
 			.readdirSync(absoluteDir)
-			.filter((f) => f.endsWith('.sql'))
+			.filter((f) => f.endsWith('.sql') || f.endsWith('.js'))
 			.sort();
 
 		// The Knex migrationsLister.js code assumes that migrations are returned as an array of objects each having a 'file'
@@ -39,6 +39,10 @@ class CustomSqlMigrationSource implements Knex.MigrationSource<any> {
 			this.migrationDirectory,
 			this.getMigrationName(migration)
 		);
+
+		if (migrationPath.endsWith('.js')) {
+			return require(migrationPath);
+		}
 
 		return {
 			up: async function up(knex: any) {

--- a/src/graphql/resolvers.itest.ts
+++ b/src/graphql/resolvers.itest.ts
@@ -134,7 +134,9 @@ describe('app/graphql', () => {
 					'characters',
 				]);
 				expect(result).toMatchObject({
-					type_defs: 'type Query { default: String }',
+					type_defs: `type Query {
+  default: String
+}`,
 				});
 			});
 		});

--- a/src/graphql/resolvers.itest.ts
+++ b/src/graphql/resolvers.itest.ts
@@ -125,6 +125,7 @@ describe('app/graphql', () => {
 				// ASSERT
 				expect(Object.keys(result)).toEqual([
 					'id',
+					'UUID',
 					'service_id',
 					'is_active',
 					'type_defs',

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -71,6 +71,7 @@ export default gql`
 
 	type SchemaDefinition {
 		id: Int!
+		UUID: String
 		service: Service!
 		isActive: Boolean!
 

--- a/src/router/schema.itest.ts
+++ b/src/router/schema.itest.ts
@@ -42,7 +42,9 @@ describe('app/controller/schema', () => {
 			expect(result2.data[0]).toMatchObject({
 				is_active: 1,
 				name: 'service_a',
-				type_defs: 'type Query { hello: String }',
+				type_defs: `type Query {
+  hello: String
+}`,
 				url: '',
 				version: 'v1',
 			});
@@ -67,7 +69,9 @@ describe('app/controller/schema', () => {
 					body: {
 						name: 'service_a',
 						version: 'v2',
-						type_defs: 'type Query { world: String }',
+						type_defs: `type Query {
+  world: String
+}`,
 						url: '',
 					},
 				},
@@ -152,7 +156,9 @@ type Query {
 					body: {
 						name: 'service_b',
 						version: 'latest', // !
-						type_defs: 'type Query { world: String }',
+						type_defs: `type Query {
+  world: String
+}`,
 						url: '',
 					},
 				},

--- a/src/router/schema.itest.ts
+++ b/src/router/schema.itest.ts
@@ -69,9 +69,7 @@ describe('app/controller/schema', () => {
 					body: {
 						name: 'service_a',
 						version: 'v2',
-						type_defs: `type Query {
-  world: String
-}`,
+						type_defs: `type Query { world: String }`,
 						url: '',
 					},
 				},
@@ -84,7 +82,9 @@ describe('app/controller/schema', () => {
 			expect(result2.data[0]).toMatchObject({
 				is_active: 1,
 				name: 'service_a',
-				type_defs: 'type Query { world: String }',
+				type_defs: `type Query {
+  world: String
+}`,
 				url: '',
 				version: 'v2',
 			});
@@ -156,9 +156,7 @@ type Query {
 					body: {
 						name: 'service_b',
 						version: 'latest', // !
-						type_defs: `type Query {
-  world: String
-}`,
+						type_defs: `type Query { world: String }`,
 						url: '',
 					},
 				},
@@ -171,7 +169,9 @@ type Query {
 			expect(result2.data[0]).toMatchObject({
 				is_active: 1,
 				name: 'service_b',
-				type_defs: 'type Query { world: String }',
+				type_defs: `type Query {
+  world: String
+}`,
 				url: '',
 				version: 'latest',
 			});

--- a/test/functional/schema/compose.test.ts
+++ b/test/functional/schema/compose.test.ts
@@ -110,7 +110,9 @@ describe('POST /schema/compose', function () {
 					id: 2,
 					is_active: 1,
 					name: 'service_a',
-					type_defs: '\n\ttype Query {\n\t\tprivet: Int\n\t}\n',
+					type_defs: `type Query {
+  privet: Int
+}`,
 					version: 'v2',
 				})
 			);
@@ -120,7 +122,9 @@ describe('POST /schema/compose', function () {
 					id: 3,
 					is_active: 1,
 					name: 'service_b',
-					type_defs: '\n\ttype Query {\n\t\tworld: String\n\t}\n',
+					type_defs: `type Query {
+  world: String
+}`,
 					version: 'v1',
 				})
 			);

--- a/test/functional/schema/latest.test.ts
+++ b/test/functional/schema/latest.test.ts
@@ -56,7 +56,9 @@ describe('GET /schema/latest', function () {
 					id: 1,
 					is_active: 1,
 					name: 'service_a',
-					type_defs: '\n\ttype Query {\n\t\thello: String\n\t}\n',
+					type_defs: `type Query {
+  hello: String
+}`,
 					url: null,
 					version: 'ke9j34fuuei',
 				})
@@ -106,7 +108,9 @@ describe('GET /schema/latest', function () {
 					id: 1,
 					is_active: 1,
 					name: 'service_a',
-					type_defs: '\n\ttype Query {\n\t\thello: String\n\t}\n',
+					type_defs: `type Query {
+  hello: String
+}`,
 					url: null,
 					version: 'ke9j34fuuei',
 				})
@@ -116,7 +120,9 @@ describe('GET /schema/latest', function () {
 					id: 2,
 					is_active: 1,
 					name: 'service_b',
-					type_defs: '\n\ttype Query {\n\t\tworld: String\n\t}\n',
+					type_defs: `type Query {
+  world: String
+}`,
 					url: null,
 					version: 'jiaj51fu91k',
 				})

--- a/test/functional/schema/push.test.ts
+++ b/test/functional/schema/push.test.ts
@@ -77,7 +77,7 @@ describe('POST /schema/push', function () {
 				expect.objectContaining({
 					success: false,
 					message: expect.stringContaining(
-						'Type of field "Query.hello" is incompatible across subgraphs'
+						'Type of field "Query.hello" is incompatible across subgraphs: it has type "String" in subgraph "service_a" but type "Int" in subgraph "service_b"'
 					),
 					details: [
 						{
@@ -85,11 +85,11 @@ describe('POST /schema/push', function () {
 								code: 'FIELD_TYPE_MISMATCH',
 							},
 							message: expect.stringContaining(
-								'Type of field "Query.hello" is incompatible across subgraphs'
+								'Type of field "Query.hello" is incompatible across subgraphs: it has type "String" in subgraph "service_a" but type "Int" in subgraph "service_b"'
 							),
 							locations: [
-								{ line: 3, column: 3 },
-								{ line: 3, column: 3 },
+								{ line: 2, column: 3 },
+								{ line: 2, column: 3 },
 							],
 						},
 					],

--- a/test/functional/schema/validate.test.ts
+++ b/test/functional/schema/validate.test.ts
@@ -95,7 +95,7 @@ describe('POST /schema/validate', function () {
 				expect.objectContaining({
 					success: false,
 					message: expect.stringContaining(
-						'Type of field "Query.hello" is incompatible across subgraphs'
+						'Type of field "Query.hello" is incompatible across subgraphs: it has type "String" in subgraph "service_a" but type "Int" in subgraph "service_b"'
 					),
 					details: [
 						{
@@ -103,10 +103,10 @@ describe('POST /schema/validate', function () {
 								code: 'FIELD_TYPE_MISMATCH',
 							},
 							message: expect.stringContaining(
-								'Type of field "Query.hello" is incompatible across subgraphs'
+								'Type of field "Query.hello" is incompatible across subgraphs: it has type "String" in subgraph "service_a" but type "Int" in subgraph "service_b"'
 							),
 							locations: [
-								{ line: 3, column: 3 },
+								{ line: 2, column: 3 },
 								{ line: 3, column: 3 },
 							],
 						},


### PR DESCRIPTION
## Problem
Schema comparison is done with mysql comparison in `schema.type_defs`
#168 + #106

## Changes
- Add schema normalization - this should get rid of extra tabbing / spacing
- Fix knex migration generation
- Improve migration scripts to support JS migrations
- Migrate schemas to now include UUID
- Do not delete duplicate schemas as its a bit dangerous

<img width="1207" alt="Screenshot 2022-10-24 at 14 22 19" src="https://user-images.githubusercontent.com/445122/197515767-0cf6487e-12b0-422c-826f-d1a935b83829.png">


## Testing
TBD