### PR TITLE
Correct functional test steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ DB tables are truncated after every test from within `test/functional/bootstrap.
 Jest runs in single worker mode to avoid tests from affecting each other due to same state.
 
 ```
-#docker-compose -f docker-compose.light.yml up -d
+#docker-compose -f docker-compose.base.yml up -d
 #npm run develop
 
-npm run test-functional
+npm run test:functional
 ```
 
 ### Performance tests


### PR DESCRIPTION
## Problem
Instructions in the README around functional testing appear to be out of date
...

## Changes
Updated README to reflect current docker image name and functional test command
- ...

## Testing
Locally tested commands 
...

Note - there may be more parts of the README requiring similar updates, I haven't checked every command documented.
