### PR TITLE
Addressing the following Redis related issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,26 +181,27 @@ You can:
 
 The following are the different environment variables that are looked up that allow configuring the schema registry in different ways.
 
-| Variable Name         | Description                                                                   | Default                   |
-| --------------------- | ----------------------------------------------------------------------------- | ------------------------- |
-| DB_HOST               | Host name of the MySQL server                                                 | gql-schema-registry-db    |
-| DB_USERNAME           | Username to connect to MySQL                                                  | root                      |
-| DB_SECRET             | Password used to connect to MySQL                                             | root                      |
-| DB_PORT               | Port used when connecting to MySQL                                            | 3306                      |
-| DB_NAME               | Name of the MySQL database to connect to                                      | schema-registry           |
-| DB_EXECUTE_MIGRATIONS | Controls whether DB migrations are executed upon registry startup or not      | true                      |
-| REDIS_HOST            | Host name of the Redis server                                                 | gql-schema-registry-redis |
-| REDIS_PORT            | Port used when connecting to Redis                                            | 6379                      |
-| REDIS_SECRET          | Password used to connect to Redis                                             | Empty                     |
-| ASSETS_URL            | Controls the url that web assets are served from                              | localhost:6001            |
-| NODE_ENV              | Specifies the environment. Use _production_ to load js/css from `dist/assets` | Empty                     |
-| ASYNC_SCHEMA_UPDATES  | Specifies if async achema updates is enabled                                  | false                     |
-| KAFKA_BROKER_HOST     | Host name of the Kafka broker, used if ASYNC_SCHEMA_UPDATES = true            | gql-schema-registry-kafka |
-| KAFKA_BROKER_PORT     | Port used when connecting to Kafka, used if ASYNC_SCHEMA_UPDATES = true       | 9092                      |
-| KAFKA_SCHEMA_TOPIC    | Topic with new schema                                                         | graphql-schema-updates    |
-| KAFKA_QUERIES_TOPIC   | Topic with new schema                                                         | graphql-queries           |
-| LOG_LEVEL             | Minimum level of logs to output                                               | info                      |
-| LOG_TYPE              | Output log type, supports pretty or json.                                     | pretty                    |
+| Variable Name          | Description                                                                   | Default                   |
+|------------------------|-------------------------------------------------------------------------------|---------------------------|
+| DB_HOST                | Host name of the MySQL server                                                 | gql-schema-registry-db    |
+| DB_USERNAME            | Username to connect to MySQL                                                  | root                      |
+| DB_SECRET              | Password used to connect to MySQL                                             | root                      |
+| DB_PORT                | Port used when connecting to MySQL                                            | 3306                      |
+| DB_NAME                | Name of the MySQL database to connect to                                      | schema-registry           |
+| DB_EXECUTE_MIGRATIONS  | Controls whether DB migrations are executed upon registry startup or not      | true                      |
+| REDIS_HOST             | Host name of the Redis server                                                 | gql-schema-registry-redis |
+| REDIS_PORT             | Port used when connecting to Redis                                            | 6379                      |
+| REDIS_SECRET           | Password used to connect to Redis                                             | Empty                     |
+| ASSETS_URL             | Controls the url that web assets are served from                              | localhost:6001            |
+| NODE_ENV               | Specifies the environment. Use _production_ to load js/css from `dist/assets` | Empty                     |
+| ASYNC_SCHEMA_UPDATES   | Specifies if async achema updates is enabled                                  | false                     |
+| KAFKA_BROKER_HOST      | Host name of the Kafka broker, used if ASYNC_SCHEMA_UPDATES = true            | gql-schema-registry-kafka |
+| KAFKA_BROKER_PORT      | Port used when connecting to Kafka, used if ASYNC_SCHEMA_UPDATES = true       | 9092                      |
+| KAFKA_SCHEMA_TOPIC     | Topic with new schema                                                         | graphql-schema-updates    |
+| KAFKA_QUERIES_TOPIC    | Topic with new schema                                                         | graphql-queries           |
+| LOG_LEVEL              | Minimum level of logs to output                                               | info                      |
+| LOG_TYPE               | Output log type, supports pretty or json.                                     | pretty                    |
+| LOG_STREAMING_ENABLED  | Controls whether logs are streamed over Redis to be presented in UI           | false                     |
 
 For development we rely on docker network and use hostnames from `docker-compose.yml`.
 Node service uses to connect to mysql & redis and change it if you install it with own setup.
@@ -390,13 +391,13 @@ See main [blog post](https://medium.com/pipedrive-engineering/journey-to-federat
 
 <details>
   <summary><h3>🟢 GET /health</h3></summary>
-  
+
   returns "ok" when service is up
 </details>
 
 <details>
   <summary><h3>🟢 GET /schema/latest</h3></summary>
-  
+
 Simplified version of /schema/compose where latest versions from different services are composed.
 Some services prefer this to use this natural schema composition, as its natural and time-based.
 
@@ -404,7 +405,7 @@ Some services prefer this to use this natural schema composition, as its natural
 
 <details>
   <summary><h3>🟡 POST /schema/compose</h3></summary>
-  
+
 Advanced version of schema composition, where you need to provide services & their versions.
 Used by graphql gateway to fetch schema based on currently running containers.
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The following are the different environment variables that are looked up that al
 | KAFKA_QUERIES_TOPIC    | Topic with new schema                                                         | graphql-queries           |
 | LOG_LEVEL              | Minimum level of logs to output                                               | info                      |
 | LOG_TYPE               | Output log type, supports pretty or json.                                     | pretty                    |
-| LOG_STREAMING_ENABLED  | Controls whether logs are streamed over Redis to be presented in UI           | false                     |
+| LOG_STREAMING_ENABLED  | Controls whether logs are streamed over Redis to be presented in UI           | true                      |
 
 For development we rely on docker network and use hostnames from `docker-compose.yml`.
 Node service uses to connect to mysql & redis and change it if you install it with own setup.

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -25,6 +25,7 @@ services:
     image: redis:6-alpine
     ports:
       - 6004:6379
+    command: redis-server --requirepass password
     environment:
       SERVICE_NAME: 'gql-schema-registry-redis'
     networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,8 @@ services:
       - KAFKA_BROKER_HOST=gql-schema-registry-kafka
       - KAFKA_BROKER_PORT=9092
       - KAFKA_SCHEMA_TOPIC=graphql-schema-updates
+      - REDIS_HOST=gql-schema-registry-redis
+      - REDIS_SECRET=password
     volumes:
       - .:/app/
     restart: always

--- a/docker-compose.functional.yml
+++ b/docker-compose.functional.yml
@@ -14,7 +14,7 @@ services:
       - DB_SCHEMA_REGISTRY=gql-schema-registry-db
       - NODE_ENV=production
       - REDIS_HOST=gql-schema-registry-redis
-      - REDIS_PASSWORD=password
+      - REDIS_SECRET=password
     volumes:
       - .:/app/
     restart: always

--- a/docker-compose.functional.yml
+++ b/docker-compose.functional.yml
@@ -13,6 +13,7 @@ services:
       - WITH_WEBPACK=${WITH_WEBPACK-1}
       - DB_SCHEMA_REGISTRY=gql-schema-registry-db
       - NODE_ENV=production
+      - REDIS_PASSWORD=password
     volumes:
       - .:/app/
     restart: always

--- a/docker-compose.functional.yml
+++ b/docker-compose.functional.yml
@@ -13,6 +13,7 @@ services:
       - WITH_WEBPACK=${WITH_WEBPACK-1}
       - DB_SCHEMA_REGISTRY=gql-schema-registry-db
       - NODE_ENV=production
+      - REDIS_HOST=gql-schema-registry-redis
       - REDIS_PASSWORD=password
     volumes:
       - .:/app/

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:unit:frontend:coverage": "jest --config test/unit-frontend/jest.config.ts --color --detectOpenHandles --forceExit",
     "test:watch": "jest --config jest.config.ts --watch",
     "test:integration": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 REDIS_SECRET=password PORT=6001 jest --config test/integration/jest.config.cjs --color --detectOpenHandles --runInBand --forceExit",
-    "test:integration:coverage": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 jest --config test/integration/jest.coverage.cjs --color --detectOpenHandles --runInBand --forceExit",
+    "test:integration:coverage": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 REDIS_SECRET=password PORT=6001 jest --config test/integration/jest.coverage.cjs --color --detectOpenHandles --runInBand --forceExit",
     "test:functional": "./node_modules/.bin/jest --config test/functional/jest.config.cjs",
     "test:performance": "TARGET_URL=localhost:6001 k6 run test/perf/minimum.test.js",
     "test:performance:dockerized": "docker-compose -f docker-compose.perf-tests.yml run --rm k6 run /scripts/minimum.test.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit:coverage": "jest --config test/unit/jest.coverage.cjs --color --detectOpenHandles --forceExit",
     "test:unit:frontend:coverage": "jest --config test/unit-frontend/jest.config.ts --color --detectOpenHandles --forceExit",
     "test:watch": "jest --config jest.config.ts --watch",
-    "test:integration": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 jest --config test/integration/jest.config.cjs --color --detectOpenHandles --runInBand --forceExit",
+    "test:integration": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 REDIS_SECRET=password PORT=6001 jest --config test/integration/jest.config.cjs --color --detectOpenHandles --runInBand --forceExit",
     "test:integration:coverage": "DB_HOST=localhost DB_PORT=6000 REDIS_HOST=localhost REDIS_PORT=6004 PORT=6001 jest --config test/integration/jest.coverage.cjs --color --detectOpenHandles --runInBand --forceExit",
     "test:functional": "./node_modules/.bin/jest --config test/functional/jest.config.cjs",
     "test:performance": "TARGET_URL=localhost:6001 k6 run test/perf/minimum.test.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,8 +25,11 @@ export default {
 		},
 	},
 	asyncSchemaUpdates: booleanFor(process.env.ASYNC_SCHEMA_UPDATES),
+	logStreamingEnabled:
+		booleanFor(process.env.LOG_STREAMING_ENABLED, 'true') &&
+		process.env.REDIS_HOST !== undefined,
 };
 
-function booleanFor(variable) {
-	return (variable || 'false').toLowerCase() === 'true';
+function booleanFor(variable, defaultValue = 'false') {
+	return (variable || defaultValue).toLowerCase() === 'true';
 }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -79,7 +79,7 @@ export default {
 			);
 
 			// @ts-ignore
-			return logs?.redis;
+			return process.env.LOG_STREAMING_ENABLED === 'true' ? logs?.redis : '';
 		},
 
 		search: async (_, { filter }) => {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -78,7 +78,7 @@ export default {
 				)
 			);
 
-			if (process.env.LOG_STREAMING_ENABLED === 'true') {
+			if (config.logStreamingEnabled) {
 				// @ts-ignore
 				return logs?.redis;
 			}

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -78,8 +78,12 @@ export default {
 				)
 			);
 
-			// @ts-ignore
-			return process.env.LOG_STREAMING_ENABLED === 'true' ? logs?.redis : '';
+			if (process.env.LOG_STREAMING_ENABLED === 'true') {
+				// @ts-ignore
+				return logs?.redis;
+			}
+
+			return '';
 		},
 
 		search: async (_, { filter }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import * as kafka from './kafka';
 import config from './config';
 import router from './router';
 import { logger } from './logger';
+import diplomat from './diplomat';
+import redis from './redis';
 
 const app = express();
 
@@ -98,6 +100,12 @@ export default async function init() {
 
 	if (server) {
 		return server;
+	}
+
+	const redisConfig = diplomat.getServiceInstance('gql-schema-registry-redis');
+
+	if (redisConfig.host) {
+		redis.initRedis();
 	}
 
 	if (config.asyncSchemaUpdates) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,9 @@ export default async function init() {
 		return server;
 	}
 
-	const redisConfig = diplomat.getServiceInstance('gql-schema-registry-redis');
+	const redisConfig = diplomat.getServiceInstance(
+		'gql-schema-registry-redis'
+	);
 
 	if (redisConfig.host) {
 		redis.initRedis();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,10 @@
 import { createLogger, transports, format } from 'winston';
 import RedisTransport from 'winston-redis-stream';
+import config from './config';
 
 const logTransports = [new transports.Console()];
 
-if (process.env.LOG_STREAMING_ENABLED === 'true' && process.env.REDIS_HOST) {
+if (config.logStreamingEnabled) {
 	try {
 		const redis = new RedisTransport({
 			redis: {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,11 +3,14 @@ import RedisTransport from 'winston-redis-stream';
 
 const logTransports = [new transports.Console()];
 
-if (process.env.REDIS_HOST) {
+if (process.env.LOG_STREAMING_ENABLED === 'true' && process.env.REDIS_HOST) {
 	try {
 		const redis = new RedisTransport({
-			host: process.env.REDIS_HOST,
-			port: process.env.REDIS_PORT,
+			redis: {
+				host: process.env.REDIS_HOST,
+				port: process.env.REDIS_PORT,
+				password: process.env.REDIS_SECRET,
+			},
 			channel: 'logs',
 		});
 		logTransports.push(redis);


### PR DESCRIPTION
## Problem

Redis seems to have become mandatory in recent releases. We have noticed a couple of issues after grabbing the latest version.

1. Failure to initialize the `RedisTransport` object in `src/logger.ts` in cases where Redis requires password authentication (which is the case in our environments).
2. It did not seem like Redis was getting initialized for the persisted query feature. It appeared that way as we were noticing Redis related warnings in the logs when exercising the persisted query feature. 
3. Streaming registry logs over Redis should be an opt in feature in our opinions, so simply checking if a Redis host is configured before enabling the feature is not enough.

## Changes

- Passing the Redis password to the `RedisTransport` constructor in `src/logger.ts`.
- Initializing Redis in the `init()` function in `src/index.ts`. With this change the warnings in the logs disappear.
- In order to cover the Redis/password cases, the `docker-compose.base.yml` now makes sure to launch Redis with password protection.
- Adding an environment variable called `LOG_STREAMING_ENABLED` to further control if log streaming over Redis should be enabled or not.

## Testing

All existing unit and integration tests are passing.