### PR TITLE
feat: Allow configuring the logical Redis DB to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Types of changes:
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+
+- Add `REDIS_DB` environment variable to customise the logical Redis database to use.
 
 ## [5.5.1] 2023-01-29
 ### Changed

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The following are the different environment variables that are looked up that al
 | REDIS_HOST             | Host name of the Redis server                                                 | gql-schema-registry-redis |
 | REDIS_PORT             | Port used when connecting to Redis                                            | 6379                      |
 | REDIS_SECRET           | Password used to connect to Redis                                             | Empty                     |
+| REDIS_DB               | Index of the logical redis database | 2            |
 
 
 For development we rely on docker network and use hostnames from `docker-compose.yml`.

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export default {
 			host: process.env.REDIS_HOST || 'gql-schema-registry-redis',
 			port: process.env.REDIS_PORT || '6379',
 			secret: process.env.REDIS_SECRET || '',
+			db: intFor(process.env.REDIS_DB, '2'),
 		},
 		'gql-schema-registry-kafka': {
 			host: process.env.KAFKA_BROKER_HOST || 'gql-schema-registry-kafka',
@@ -32,4 +33,12 @@ export default {
 
 function booleanFor(variable, defaultValue = 'false') {
 	return (variable || defaultValue).toLowerCase() === 'true';
+}
+
+function intFor(variable, defaultValue = '0') {
+	const parsed = parseInt(variable || defaultValue);
+	if (isNaN(parsed)) {
+		return parseInt(defaultValue);
+	}
+	return parsed;
 }

--- a/src/redis/index.ts
+++ b/src/redis/index.ts
@@ -25,9 +25,10 @@ async function resolveInstance(service) {
 			port,
 			username,
 			secret: password,
+			db,
 		} = await diplomat.getServiceInstance(service);
 
-		return { host, port, username, password };
+		return { host, port, username, password, db };
 	} catch (err) {
 		logger.warn(err, 'Redis discovery failed');
 


### PR DESCRIPTION
## Problem

Currently, the Redis DB is hardcoded to be 2, which means that there is the potential for conflicts when using a shared Redis instance where that DB index is already taken.

## Changes

- Added `REDIS_DB` environment variable to allow customising the logical Redis DB to use.
