### PR TITLE
Add supergraph endpoint

### DIFF
--- a/docker-compose.apollo.yml
+++ b/docker-compose.apollo.yml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  apollo-router:
+    image: ghcr.io/apollographql/router:v1.42.0
+    command: --dev --hot-reload --supergraph /tmp/supergraph.graphql --log trace
+    ports:
+      - 4000:4000
+    volumes:
+      - gql-supergraph-schema:/tmp
+      - ./examples/apollo-router/router.yaml:/router.yaml
+    restart: always
+    depends_on:
+      - gql-supergraph-updater
+    networks:
+      - gql-schema
+
+  gql-supergraph-updater:
+    image: quay.io/curl/curl:8.6.0
+    command: watch -n 10 curl --show-error --silent http://gql-schema-registry:3000/schema/supergraph -o /tmp/supergraph.graphql
+    volumes:
+      - gql-supergraph-schema:/tmp
+    depends_on:
+      - gql-schema-registry
+    networks:
+      - gql-schema
+
+volumes:
+  gql-supergraph-schema:
+
+networks:
+  gql-schema:

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,3 +48,22 @@ Directories:
 - **gateway_service_managed_federation**
 - federated_service_a
 - federated_service_b
+
+## Schema registry, with Apollo Router for federation
+
+Mostly same setup as above but instead of using the example gateway we'll be using [Apollo Router](https://www.apollographql.com/docs/router).
+
+- Start graphql-schema-registry with apollo-router. Wait until DB & UI work at http://localhost:6001/
+
+```
+docker-compose -f docker-compose.base.yml -f docker-compose.prod.yml -f docker-compose.apollo.yml up
+```
+
+- The Apollo Router will not be available until we register our first service, so (in separate terminals) start federated services
+
+```
+cd federated_service_a && npm install && node index.js
+cd federated_service_b && npm install && node index.js
+```
+
+- Check Apollo Router playground UI in the browser at http://localhost:4000/

--- a/examples/apollo-router/router.yaml
+++ b/examples/apollo-router/router.yaml
@@ -1,0 +1,2 @@
+supergraph:
+    listen: 0.0.0.0:4001

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "request-promise-native": "^1.0.8",
         "sinon": "^8.0.1",
         "source-map-loader": "^3.0.1",
+        "supertest": "6.3.4",
         "ts-jest": "^27.1.4",
         "ts-node": "^10.7.0",
         "ts-node-dev": "^2.0.0-0",
@@ -5432,6 +5433,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -6331,6 +6338,15 @@
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6381,6 +6397,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/core-js": {
       "version": "3.22.4",
@@ -7323,6 +7345,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -8600,6 +8632,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -9004,6 +9042,21 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -9396,6 +9449,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/history": {
@@ -15789,6 +15851,104 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -21294,6 +21454,12 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -22005,6 +22171,12 @@
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -22048,6 +22220,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "core-js": {
       "version": "3.22.4",
@@ -22773,6 +22951,16 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff": {
       "version": "4.0.2",
@@ -23734,6 +23922,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -24027,6 +24221,18 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
+      "requires": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -24303,6 +24509,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
       "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+      "dev": true
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
     "history": {
@@ -29030,6 +29242,77 @@
       "requires": {
         "browserslist": "^4.16.6",
         "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "request-promise-native": "^1.0.8",
     "sinon": "^8.0.1",
     "source-map-loader": "^3.0.1",
+    "supertest": "6.3.4",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
     "ts-node-dev": "^2.0.0-0",

--- a/src/controller/schema.ts
+++ b/src/controller/schema.ts
@@ -29,6 +29,20 @@ export async function getAndValidateSchema(
 	return schemas;
 }
 
+export async function composeSupergraph(trx) {
+	const schemas = await schemaModel.getLastUpdatedForActiveServices({ trx });
+
+	logger.info('Composing graph. Got services schemas from DB transaction..', {
+		schemas,
+	});
+
+	if (schemas && schemas.length) {
+		return federationHelper.composeSupergraph(schemas);
+	}
+
+	return '';
+}
+
 export async function pushAndValidateSchema({ service }) {
 	return await transact(async (trx) => {
 		const schema = await schemaModel.registerSchema({ trx, service });

--- a/src/helpers/federation.ts
+++ b/src/helpers/federation.ts
@@ -35,3 +35,35 @@ export function composeAndValidateSchema(servicesSchemaMap) {
 
 	return schema;
 }
+
+export function composeSupergraph(servicesSchemaMap) {
+	let supergraphSdl;
+	let errors = [];
+
+	try {
+		const serviceList = servicesSchemaMap.map((schema) => {
+			const typeDefs = parse(schema.type_defs);
+
+			return {
+				name: schema.name,
+				url: schema.url,
+				typeDefs,
+			};
+		});
+
+		({ supergraphSdl, errors } = composeServices(serviceList));
+	} catch (error) {
+		logger.error(error.message);
+
+		errors = [error];
+	}
+
+	if (errors && errors.length) {
+		logger.error(errors);
+		throw new PublicError('Schema validation failed', {
+			details: errors,
+		});
+	}
+
+	return supergraphSdl;
+}

--- a/src/helpers/federation.ts
+++ b/src/helpers/federation.ts
@@ -60,7 +60,7 @@ export function composeSupergraph(servicesSchemaMap) {
 
 	if (errors && errors.length) {
 		logger.error(errors);
-		throw new PublicError('Schema validation failed', {
+		throw new PublicError('Schema composition failed', {
 			details: errors,
 		});
 	}

--- a/src/helpers/middleware.ts
+++ b/src/helpers/middleware.ts
@@ -1,5 +1,48 @@
+import { logger } from '../logger';
+
 export function asyncWrap(fn) {
 	return (req, res, next) => {
 		Promise.resolve(fn(req, res, next)).catch(next);
+	};
+}
+
+export function cache(key) {
+	return (req, res, next) => {
+		const locals = req.app.locals;
+		if (!locals.cache) {
+			locals.cache = {};
+		}
+
+		const cached = locals.cache[key];
+		if (cached) {
+			logger.info(`Sending cached: ${key}`);
+			res.set(cached.headers);
+			return res.send(cached.body);
+		} else {
+			res.__send = res.send;
+			res.send = (body) => {
+				locals.cache[key] = {
+					body,
+					headers: res.getHeaders(),
+				};
+				res.__send(body);
+				logger.info(`Cached: ${key}`);
+			};
+		}
+		next();
+	};
+}
+
+export function invalidate(key) {
+	return (req, res, next) => {
+		const locals = req.app.locals;
+		if (!locals.cache) {
+			return next();
+		}
+
+		logger.info(`Invalidating: ${key}`);
+		delete locals.cache[key];
+
+		return next();
 	};
 }

--- a/src/helpers/middleware.ts
+++ b/src/helpers/middleware.ts
@@ -40,8 +40,13 @@ export function invalidate(key) {
 			return next();
 		}
 
-		logger.info(`Invalidating: ${key}`);
-		delete locals.cache[key];
+		res.__end = res.end;
+		res.end = (data, encoding, callback) => {
+			logger.info(`Invalidating: ${key}`);
+			delete locals.cache[key];
+
+			res.__end(data, encoding, callback);
+		};
 
 		return next();
 	};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -31,10 +31,14 @@ export const logger = createLogger({
 
 function buildPrettyFormat() {
 	return format.combine(
+		format.errors({ stack: true }),
 		format.colorize(),
 		format.timestamp(),
 		format.printf(({ timestamp, level, message, stack }) => {
-			return `[${timestamp}] ${level}: ${message} ${stack}`;
+			if (stack) {
+				return `[${timestamp}] ${level}: ${message} ${stack}`;
+			}
+			return `[${timestamp}] ${level}: ${message}`;
 		})
 	);
 }

--- a/src/router/index.itest.ts
+++ b/src/router/index.itest.ts
@@ -43,6 +43,49 @@ describe('app/router/supergraph', function () {
 		expect(pre.text).not.toBe(post.text);
 	});
 
+	it('rollback returns same supergraph', async () => {
+		let old_schema = {
+			name: 'service_a',
+			version: 'v1',
+			type_defs: 'type Query { hello: String }',
+			url: '',
+		};
+		let res = await request(app)
+			.post('/schema/push')
+			.send(old_schema)
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		let pre = await request(app).get('/schema/supergraph');
+		expect(res.statusCode).toBe(200);
+
+		res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v2',
+				type_defs: 'type Query { world: String }',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		res = await request(app).get('/schema/supergraph');
+		expect(res.statusCode).toBe(200);
+
+		old_schema.version = 'v3';
+		res = await request(app)
+			.post('/schema/push')
+			.send(old_schema)
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		let post = await request(app).get('/schema/supergraph');
+		expect(res.statusCode).toBe(200);
+
+		expect(pre.text).toBe(post.text);
+	});
+
 	it('invalid push returns same supergraph ', async () => {
 		let res = await request(app)
 			.post('/schema/push')

--- a/src/router/index.itest.ts
+++ b/src/router/index.itest.ts
@@ -1,0 +1,126 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../router';
+import { cleanTables } from '../../test/integration/database';
+
+const app = express();
+app.use('/', router);
+
+describe('app/router/supergraph', function () {
+	beforeEach(async () => {
+		await cleanTables();
+	});
+
+	it('push updates supergraph ', async () => {
+		let res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v1',
+				type_defs: 'type Query { hello: String }',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		const pre = await request(app).get('/schema/supergraph');
+		expect(pre.statusCode).toBe(200);
+
+		res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v2',
+				type_defs: 'type Query { world: String }',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		const post = await request(app).get('/schema/supergraph');
+		expect(post.statusCode).toBe(200);
+
+		expect(pre.text).not.toBe(post.text);
+	});
+
+	it('invalid push returns same supergraph ', async () => {
+		let res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v1',
+				type_defs: 'type Query { hello: String }',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		const pre = await request(app).get('/schema/supergraph');
+		expect(pre.statusCode).toBe(200);
+
+		res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v2',
+				type_defs: 'type Broken {}',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(500);
+
+		const post = await request(app).get('/schema/supergraph');
+		expect(post.statusCode).toBe(200);
+
+		expect(pre.text).toBe(post.text);
+	});
+
+	it('delete schema updates supergraph ', async () => {
+		let res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v1',
+				type_defs: 'type Query { hello: String }',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+		const schemaId = res.body.data.schema_id;
+
+		const pre = await request(app).get('/schema/supergraph');
+		expect(pre.statusCode).toBe(200);
+
+		res = await request(app).delete(`/schema/${schemaId}`);
+		expect(res.statusCode).toBe(200);
+
+		const post = await request(app).get('/schema/supergraph');
+		expect(post.statusCode).toBe(200);
+
+		expect(pre.text).not.toBe(post.text);
+	});
+
+	it('delete service updates supergraph ', async () => {
+		let res = await request(app)
+			.post('/schema/push')
+			.send({
+				name: 'service_a',
+				version: 'v1',
+				type_defs: 'type Query { hello: String }',
+				url: '',
+			})
+			.set('Accept', 'application/json');
+		expect(res.statusCode).toBe(200);
+
+		const pre = await request(app).get('/schema/supergraph');
+		expect(pre.statusCode).toBe(200);
+
+		res = await request(app).delete('/service/service_a');
+		expect(res.statusCode).toBe(200);
+
+		const post = await request(app).get('/schema/supergraph');
+		expect(post.statusCode).toBe(200);
+
+		expect(pre.text).not.toBe(post.text);
+	});
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -58,20 +58,20 @@ router.get(
 	asyncWrap(schema.supergraph)
 );
 router.post('/schema/compose', asyncWrap(schema.compose));
-router.post('/schema/push', asyncWrap(schema.push), invalidate(supergraphKey));
+router.post('/schema/push', invalidate(supergraphKey), asyncWrap(schema.push));
 router.post('/schema/diff', asyncWrap(schema.diff));
 
 router.delete(
 	'/schema/:schemaId',
-	asyncWrap(schema.remove),
-	invalidate(supergraphKey)
+	invalidate(supergraphKey),
+	asyncWrap(schema.remove)
 );
 router.post('/schema/validate', asyncWrap(schema.validate));
 
 router.delete(
 	'/service/:name',
-	asyncWrap(service.remove),
-	invalidate(supergraphKey)
+	invalidate(supergraphKey),
+	asyncWrap(service.remove)
 );
 
 export default router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -58,20 +58,20 @@ router.get(
 	asyncWrap(schema.supergraph)
 );
 router.post('/schema/compose', asyncWrap(schema.compose));
-router.post('/schema/push', invalidate(supergraphKey), asyncWrap(schema.push));
+router.post('/schema/push', asyncWrap(schema.push), invalidate(supergraphKey));
 router.post('/schema/diff', asyncWrap(schema.diff));
 
 router.delete(
 	'/schema/:schemaId',
-	invalidate(supergraphKey),
-	asyncWrap(schema.remove)
+	asyncWrap(schema.remove),
+	invalidate(supergraphKey)
 );
 router.post('/schema/validate', asyncWrap(schema.validate));
 
 router.delete(
 	'/service/:name',
-	invalidate(supergraphKey),
-	asyncWrap(service.remove)
+	asyncWrap(service.remove),
+	invalidate(supergraphKey)
 );
 
 export default router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -50,6 +50,7 @@ router.get('/persisted_query', asyncWrap(persistedQuery.get));
 router.post('/persisted_query', asyncWrap(persistedQuery.create));
 
 router.get('/schema/latest', asyncWrap(schema.composeLatest));
+router.get('/schema/supergraph', asyncWrap(schema.supergraph));
 router.post('/schema/compose', asyncWrap(schema.compose));
 router.post('/schema/push', asyncWrap(schema.push));
 router.post('/schema/diff', asyncWrap(schema.diff));

--- a/src/router/schema.ts
+++ b/src/router/schema.ts
@@ -5,6 +5,7 @@ import {
 	pushAndValidateSchema,
 	deactivateSchema,
 	diffSchemas,
+	composeSupergraph,
 } from '../controller/schema';
 import { connection } from '../database';
 import config from '../config';
@@ -17,6 +18,12 @@ export async function composeLatest(req, res) {
 		success: true,
 		data: schema,
 	});
+}
+
+export async function supergraph(req, res) {
+	const sdl = await composeSupergraph(connection);
+
+	return res.set('Content-Type', 'text/plain').send(sdl);
 }
 
 export async function compose(req, res) {


### PR DESCRIPTION
## Problem

In order to use Apollo Router #162 one needs a composed supergraph to provide to it.
While this can be done using Rover CLI or via @apollo/composition it's not very easy to do it and may require an extra infrastructure component. 

## Changes

New `/schema/supegraph` that can be passed directly to the router.
Endpoint is cached in memory (without other deps), and is invalidated on subgraph changes.

Example Helm values for [Apollo Router](https://github.com/apollographql/router/tree/dev/helm/chart/router):

```yaml
router:
  args:
    - --hot-reload
    - -s
    - /tmp/supergraph.graphql
extraContainers:
  - name: update-graph
    image: quay.io/curl/curl:8.4.0
    command: ["watch"]
    args: ["-n", "60", "curl", "-v", "http://graphql-schema-registry/schema/supergraph", "-o", "/tmp/supergraph.graphql"]
    volumeMounts:
    - name: schema
      mountPath: /tmp/
extraVolumes:
  - name: schema
    emptyDir: {}
extraVolumeMounts:
  - name: schema
    mountPath: /tmp/
    readOnly: true
```
