### PR TITLE
fix(dev): remove USER nobody from dev Dockerfile and add auto database creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,16 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `USER nobody` from dev.Dockerfile to fix webpack permission errors in development
+
+### Added
+
+- Auto-create database if it doesn't exist during startup
+
 ### [5.5.4] 2025-05-11
+
 - Apollo v2 federation support
 
 ### [5.5.3] 2025-05-10

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,7 +1,5 @@
 FROM node:22-alpine
 
-USER nobody
-
 # ensure all directories exist
 WORKDIR /app
 

--- a/src/schema-registry.ts
+++ b/src/schema-registry.ts
@@ -3,6 +3,8 @@ import CustomSqlMigrationSource from './database/sql-migration-source';
 import { connection } from './database';
 import init from './index';
 import { logger } from './logger';
+import config from './config';
+import knex from 'knex';
 
 dotenv.config();
 
@@ -22,6 +24,42 @@ process.on('uncaughtException', (error: Error) => {
 
 logger.info(`Starting schema-registry...`);
 
+async function createDatabaseIfNotExists() {
+	const dbConfig = config.serviceDiscovery['gql-schema-registry-db'];
+	const dbName = dbConfig.name;
+
+	const adminConnection = knex({
+		client: 'mysql2',
+		connection: {
+			host: dbConfig.host,
+			port: parseInt(dbConfig.port),
+			user: dbConfig.username,
+			password: dbConfig.secret,
+			connectTimeout: 5000,
+		},
+	});
+
+	try {
+		const result = await adminConnection.raw(
+			`SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?`,
+			[dbName]
+		);
+
+		if (result[0].length === 0) {
+			logger.info(`Database '${dbName}' does not exist. Creating it...`);
+			await adminConnection.raw(`CREATE DATABASE \`${dbName}\``);
+			logger.info(`Database '${dbName}' created successfully.`);
+		} else {
+			logger.info(`Database '${dbName}' already exists.`);
+		}
+	} catch (error) {
+		logger.error(`Failed to create database: ${error.message}`);
+		throw error;
+	} finally {
+		await adminConnection.destroy();
+	}
+}
+
 async function warmup() {
 	logger.info('Warming up');
 	logger.info(
@@ -36,6 +74,7 @@ async function warmup() {
 
 	try {
 		if (executeMigrations === 'true') {
+			await createDatabaseIfNotExists();
 			await connection.migrate.latest({
 				migrationSource: new CustomSqlMigrationSource('./migrations'),
 				disableMigrationsListValidation: true,


### PR DESCRIPTION
## Summary

This PR fixes development environment issues related to Docker permissions and database setup.

### Changes

#### Fixed
- **Remove `USER nobody` from dev.Dockerfile** - Fixes webpack permission errors (EACCES) when writing compiled assets to `/app/dist/assets` in development environment. The bind mount inherits host permissions, causing conflicts when the container runs as `nobody` (UID 65534) but the directory is owned by the host user.

#### Added  
- **Auto-create database if it doesn't exist** - Added `createDatabaseIfNotExists()` function in `src/schema-registry.ts` that automatically creates the database during startup if it doesn't already exist. This improves the developer experience by eliminating manual database setup steps.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] Updated CHANGELOG.md
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Changes are backwards compatible