### PR TITLE
feat: expand analytics views and add hourly usage tracking

### DIFF
--- a/client/analytics/index.jsx
+++ b/client/analytics/index.jsx
@@ -4,81 +4,818 @@ import {
 	useHistory,
 	useRouteMatch,
 } from 'react-router-dom';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@apollo/client';
+import { Chart, LineSeries } from 'lightweight-charts-react-components';
 
 import SpinnerCenter from '../components/SpinnerCenter';
 import Info from '../components/Info';
-import { SCHEMA_FIELDS_USAGE } from '../utils/queries';
-import UsageGraph from '../schema/service-details/UsageTab/graph';
+import {
+	SCHEMA_ENTITY_HITS,
+	SCHEMA_FIELDS_USAGE,
+	SCHEMA_OPERATION_HITS,
+} from '../utils/queries';
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+const lineColors = [
+	'#1E88E5',
+	'#D81B60',
+	'#43A047',
+	'#FB8C00',
+	'#8E24AA',
+	'#00ACC1',
+	'#5E35B1',
+	'#F4511E',
+	'#3949AB',
+	'#6D4C41',
+];
+
+function bucketToTimestamp(bucket) {
+	const parsedMs = Date.parse(bucket.includes('T') ? bucket : `${bucket}T00:00:00Z`);
+
+	if (Number.isNaN(parsedMs)) {
+		return null;
+	}
+
+	return Math.floor(parsedMs / 1000);
+}
+
+function hitsByKey(row, key) {
+	if (key === 'hits1h') {
+		return Number(row.hits1h) || 0;
+	}
+
+	if (key === 'hits24h') {
+		return Number(row.hits24h) || 0;
+	}
+
+	return Number(row.hitsSum) || 0;
+}
+
+function sortRows(rows, sortBy, sortDirection) {
+	const sortedRows = [...rows];
+
+	sortedRows.sort((rowA, rowB) => {
+		if (sortBy === 'entity') {
+			const keyA = rowA.property ? `${rowA.entity}.${rowA.property}` : rowA.entity;
+			const keyB = rowB.property ? `${rowB.entity}.${rowB.property}` : rowB.entity;
+
+			return sortDirection === 'asc'
+				? keyA.localeCompare(keyB)
+				: keyB.localeCompare(keyA);
+		}
+
+		const hitsA = hitsByKey(rowA, sortBy);
+		const hitsB = hitsByKey(rowB, sortBy);
+
+		if (hitsA === hitsB) {
+			const keyA = rowA.property ? `${rowA.entity}.${rowA.property}` : rowA.entity;
+			const keyB = rowB.property ? `${rowB.entity}.${rowB.property}` : rowB.entity;
+			return keyA.localeCompare(keyB);
+		}
+
+		return sortDirection === 'asc' ? hitsA - hitsB : hitsB - hitsA;
+	});
+
+	return sortedRows;
+}
 
 function AnalyticsContent() {
 	const history = useHistory();
 	const match = useRouteMatch('/:selectedEntity?/:selectedProperty?');
 	const selectedEntity = match?.params?.selectedEntity;
 	const selectedProperty = match?.params?.selectedProperty;
-	const entity = selectedEntity;
-	const property = selectedProperty;
+	const [activeTab, setActiveTab] = useState('entity');
+	const [searchTerm, setSearchTerm] = useState('');
+	const [topLimit, setTopLimit] = useState('50');
+	const [sortBy, setSortBy] = useState('hits24h');
+	const [sortDirection, setSortDirection] = useState('desc');
+	const [operationSortBy, setOperationSortBy] = useState('hits24h');
+	const [operationSortDirection, setOperationSortDirection] = useState('desc');
 
-	const { data, loading } = useQuery(SCHEMA_FIELDS_USAGE);
+	const { data: fieldsData, loading: fieldsLoading } = useQuery(SCHEMA_FIELDS_USAGE);
+	const { data: entityHitsData, loading: entityHitsLoading } = useQuery(
+		SCHEMA_ENTITY_HITS,
+		{
+			variables: {
+				granularity: 'HOUR',
+				hours: 24,
+			},
+		}
+	);
+	const { data: operationHitsData, loading: operationHitsLoading } = useQuery(
+		SCHEMA_OPERATION_HITS,
+		{
+			variables: {
+				granularity: 'HOUR',
+				hours: 24,
+			},
+		}
+	);
+	const allPropertyRows = fieldsData?.schemaFieldsUsage || [];
+	const allEntityRows = useMemo(() => {
+		const entityMap = new Map();
 
-	if (loading) {
+		for (const row of allPropertyRows) {
+			if (!entityMap.has(row.entity)) {
+				entityMap.set(row.entity, {
+					entity: row.entity,
+					hits1h: 0,
+					hits24h: 0,
+					hitsSum: 0,
+				});
+			}
+
+			const current = entityMap.get(row.entity);
+			current.hits1h += Number(row.hits1h) || 0;
+			current.hits24h += Number(row.hits24h) || 0;
+			current.hitsSum += Number(row.hitsSum) || 0;
+		}
+
+		return Array.from(entityMap.values());
+	}, [allPropertyRows]);
+	const isEntityTab = activeTab === 'entity';
+	const isPropertyTab = activeTab === 'property';
+	const isOperationTab = activeTab === 'operation';
+	const baseRows = isEntityTab ? allEntityRows : allPropertyRows;
+	const filteredRows = useMemo(() => {
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+
+		if (!normalizedTerm) {
+			return baseRows;
+		}
+
+		return baseRows.filter((row) => {
+			const key = row.property
+				? `${row.entity}.${row.property}`.toLowerCase()
+				: row.entity.toLowerCase();
+			return key.includes(normalizedTerm);
+		});
+	}, [baseRows, searchTerm]);
+
+	const sortedRows = useMemo(
+		() => sortRows(filteredRows, sortBy, sortDirection),
+		[filteredRows, sortBy, sortDirection]
+	);
+
+	const visibleRows = useMemo(() => {
+		if (topLimit === 'all') {
+			return sortedRows;
+		}
+
+		const parsedTopLimit = Number(topLimit);
+		if (!parsedTopLimit || parsedTopLimit <= 0) {
+			return sortedRows;
+		}
+
+		return sortedRows.slice(0, parsedTopLimit);
+	}, [sortedRows, topLimit]);
+
+	const entityChartSeries = useMemo(() => {
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const hitsRows = entityHitsData?.schemaEntityHits || [];
+		const byEntity = new Map();
+
+		for (const row of hitsRows) {
+			if (
+				normalizedTerm &&
+				!String(row.entity || '')
+					.toLowerCase()
+					.includes(normalizedTerm)
+			) {
+				continue;
+			}
+
+			const time = bucketToTimestamp(row.bucket);
+			if (time === null) {
+				continue;
+			}
+
+			if (!byEntity.has(row.entity)) {
+				byEntity.set(row.entity, []);
+			}
+
+			byEntity.get(row.entity).push({
+				time,
+				value: Number(row.hits) || 0,
+			});
+		}
+
+		const result = [];
+		for (const [entity, dataPoints] of byEntity.entries()) {
+			dataPoints.sort((a, b) => a.time - b.time);
+			result.push({ key: entity, title: entity, data: dataPoints });
+		}
+
+		result.sort((a, b) => a.title.localeCompare(b.title));
+		return result;
+	}, [entityHitsData, searchTerm]);
+
+	const operationChartSeries = useMemo(() => {
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const hitsRows = operationHitsData?.schemaOperationHits || [];
+		const byOperation = new Map();
+
+		for (const row of hitsRows) {
+			const key = `${row.operationType}:${row.operationName}`;
+			const label = `${row.operationType} ${row.operationName}`;
+
+			if (
+				normalizedTerm &&
+				!label.toLowerCase().includes(normalizedTerm)
+			) {
+				continue;
+			}
+
+			const time = bucketToTimestamp(row.bucket);
+			if (time === null) {
+				continue;
+			}
+
+			if (!byOperation.has(key)) {
+				byOperation.set(key, { title: label, data: [] });
+			}
+
+			byOperation.get(key).data.push({
+				time,
+				value: Number(row.hits) || 0,
+			});
+		}
+
+		const result = [];
+		for (const [key, series] of byOperation.entries()) {
+			series.data.sort((a, b) => a.time - b.time);
+			result.push({ key, title: series.title, data: series.data });
+		}
+
+		result.sort((a, b) => a.title.localeCompare(b.title));
+		return result;
+	}, [operationHitsData, searchTerm]);
+
+	const chartSeries = isOperationTab ? operationChartSeries : entityChartSeries;
+
+	const operationRows = useMemo(() => {
+		const byOperation = new Map();
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const nowSec = Math.floor(Date.now() / 1000);
+		const last1hCutoffSec = nowSec - 60 * 60;
+		const rows = operationHitsData?.schemaOperationHits || [];
+
+		for (const row of rows) {
+			const label = `${row.operationType} ${row.operationName}`;
+
+			if (normalizedTerm && !label.toLowerCase().includes(normalizedTerm)) {
+				continue;
+			}
+
+			const key = `${row.operationType}:${row.operationName}`;
+			const bucketSec = bucketToTimestamp(row.bucket);
+			const hits = Number(row.hits) || 0;
+
+			if (!byOperation.has(key)) {
+				byOperation.set(key, {
+					operationName: row.operationName,
+					operationType: row.operationType,
+					hits1h: 0,
+					hits24h: 0,
+				});
+			}
+
+			const entry = byOperation.get(key);
+			entry.hits24h += hits;
+
+			if (bucketSec !== null && bucketSec >= last1hCutoffSec) {
+				entry.hits1h += hits;
+			}
+		}
+
+		return Array.from(byOperation.values());
+	}, [operationHitsData, searchTerm]);
+
+	const sortedOperationRows = useMemo(() => {
+		const rows = [...operationRows];
+
+		rows.sort((rowA, rowB) => {
+			if (operationSortBy === 'operation') {
+				const labelA = `${rowA.operationType} ${rowA.operationName}`;
+				const labelB = `${rowB.operationType} ${rowB.operationName}`;
+
+				return operationSortDirection === 'asc'
+					? labelA.localeCompare(labelB)
+					: labelB.localeCompare(labelA);
+			}
+
+			const hitsA = operationSortBy === 'hits1h' ? rowA.hits1h : rowA.hits24h;
+			const hitsB = operationSortBy === 'hits1h' ? rowB.hits1h : rowB.hits24h;
+
+			if (hitsA === hitsB) {
+				const labelA = `${rowA.operationType} ${rowA.operationName}`;
+				const labelB = `${rowB.operationType} ${rowB.operationName}`;
+				return labelA.localeCompare(labelB);
+			}
+
+			return operationSortDirection === 'asc' ? hitsA - hitsB : hitsB - hitsA;
+		});
+
+		return rows;
+	}, [operationRows, operationSortBy, operationSortDirection]);
+
+	const visibleOperationRows = useMemo(() => {
+		if (topLimit === 'all') {
+			return sortedOperationRows;
+		}
+
+		const parsedTopLimit = Number(topLimit);
+		if (!parsedTopLimit || parsedTopLimit <= 0) {
+			return sortedOperationRows;
+		}
+
+		return sortedOperationRows.slice(0, parsedTopLimit);
+	}, [sortedOperationRows, topLimit]);
+
+	if (
+		fieldsLoading ||
+		entityHitsLoading ||
+		operationHitsLoading
+	) {
 		return <SpinnerCenter />;
 	}
 
-	if (!data || !data.schemaFieldsUsage.length) {
+	if (!allPropertyRows.length) {
 		return <Info>No usage data logged yet</Info>;
 	}
 
+	const onSortChange = (nextSortBy, defaultDirection = 'desc') => {
+		if (sortBy === nextSortBy) {
+			setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+			return;
+		}
+
+		setSortBy(nextSortBy);
+		setSortDirection(defaultDirection);
+	};
+
+	const onOperationSortChange = (nextSortBy, defaultDirection = 'desc') => {
+		if (operationSortBy === nextSortBy) {
+			setOperationSortDirection(operationSortDirection === 'asc' ? 'desc' : 'asc');
+			return;
+		}
+
+		setOperationSortBy(nextSortBy);
+		setOperationSortDirection(defaultDirection);
+	};
+
 	return (
-		<div style={{ display: 'flex' }}>
-			<div style={{ padding: '20px', maxWidth: '500px' }}>
-				<table width="100%">
-					<thead>
-						<tr>
-							<th>Entity</th>
-							<th>Total hits</th>
-						</tr>
-					</thead>
-					<tbody>
-						{data.schemaFieldsUsage.map((row) => {
-							const selected =
-								entity === row.entity && property === row.property;
-
-							return (
-								<tr key={`${row.entity}.${row.property}`}>
-									<td
-										style={{
-											textDecoration: 'underline',
-											cursor: 'pointer',
-											color: selected ? '#3179e2' : 'black',
-											fontWeight: selected ? 'bold' : 'normal',
-										}}
-										onClick={() => {
-											history.push(`/${row.entity}/${row.property}`);
-										}}
-									>
-										{row.entity}.{row.property}
-									</td>
-
-									<td align={'center'}>{row.hitsSum}</td>
-								</tr>
-							);
-						})}
-					</tbody>
-				</table>
-			</div>
-
-			{entity && property && (
-				<div
+		<div style={{ padding: '16px' }}>
+			<div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+				<button
+					type="button"
+					onClick={() => setActiveTab('entity')}
 					style={{
-						flexGrow: '1',
-						border: '1px',
-						borderColor: '#EEEEEE',
-						borderStyle: 'solid',
-						textAlign: 'center',
+						padding: '8px 12px',
+						border: '1px solid #DDDDDD',
+						background: activeTab === 'entity' ? '#F0F6FF' : '#FFFFFF',
+						cursor: 'pointer',
+						fontWeight: activeTab === 'entity' ? 'bold' : 'normal',
 					}}
 				>
-					<UsageGraph entity={entity} property={property} />
+					Entities
+				</button>
+				<button
+					type="button"
+					onClick={() => setActiveTab('property')}
+					style={{
+						padding: '8px 12px',
+						border: '1px solid #DDDDDD',
+						background: isPropertyTab ? '#F0F6FF' : '#FFFFFF',
+						cursor: 'pointer',
+						fontWeight: isPropertyTab ? 'bold' : 'normal',
+					}}
+				>
+					Properties
+				</button>
+				<button
+					type="button"
+					onClick={() => setActiveTab('operation')}
+					style={{
+						padding: '8px 12px',
+						border: '1px solid #DDDDDD',
+						background: activeTab === 'operation' ? '#F0F6FF' : '#FFFFFF',
+						cursor: 'pointer',
+						fontWeight: activeTab === 'operation' ? 'bold' : 'normal',
+					}}
+				>
+					Operations
+				</button>
+			</div>
+
+			{!isPropertyTab && (
+				<div
+					style={{
+						border: '1px solid #EEEEEE',
+						padding: '12px',
+						marginBottom: '16px',
+					}}
+				>
+					<div
+						style={{
+							display: 'flex',
+							justifyContent: 'space-between',
+							alignItems: 'center',
+							marginBottom: '8px',
+						}}
+					>
+						<div style={{ fontWeight: 'bold' }}>
+							{isOperationTab
+								? 'Operation hits (last 24h, 1h buckets)'
+								: 'Entity hits (last 24h, 1h buckets)'}
+						</div>
+					</div>
+					{chartSeries.length === 0 ? (
+						<Info>No chart data for selected filters</Info>
+					) : (
+						<Chart
+							options={{
+								layout: { attributionLogo: false },
+								height: 280,
+								timeScale: {
+									timeVisible: true,
+									secondsVisible: false,
+								},
+								rightPriceScale: {
+									autoScale: true,
+								},
+							}}
+							containerProps={{
+								style: {
+									width: '100%',
+									height: '280px',
+								},
+							}}
+						>
+							{chartSeries.map((seriesRow, index) => (
+								<LineSeries
+									key={seriesRow.key}
+									data={seriesRow.data}
+									options={{
+										color: lineColors[index % lineColors.length],
+										lineWidth: 2,
+										title: seriesRow.title,
+									}}
+								/>
+							))}
+						</Chart>
+					)}
+				</div>
+			)}
+
+			{(isEntityTab || isPropertyTab) && (
+				<div
+					style={{
+						display: 'flex',
+						gap: '12px',
+						marginBottom: '16px',
+						flexWrap: 'wrap',
+					}}
+				>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>{isEntityTab ? 'Entities (shown)' : 'Properties (shown)'}</div>
+						<strong>{numberFormatter.format(visibleRows.length)}</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Hits (1h)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleRows.reduce((sum, row) => sum + (Number(row.hits1h) || 0), 0)
+							)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Hits (24h)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleRows.reduce((sum, row) => sum + (Number(row.hits24h) || 0), 0)
+							)}
+						</strong>
+					</div>
+					{isPropertyTab && (
+						<div
+							style={{
+								border: '1px solid #EEEEEE',
+								padding: '12px 16px',
+								minWidth: '150px',
+							}}
+						>
+							<div>Hits (total)</div>
+							<strong>
+								{numberFormatter.format(
+									visibleRows.reduce((sum, row) => sum + (Number(row.hitsSum) || 0), 0)
+								)}
+							</strong>
+						</div>
+					)}
+				</div>
+			)}
+
+			{activeTab === 'operation' && (
+				<div
+					style={{
+						display: 'flex',
+						gap: '12px',
+						marginBottom: '16px',
+						flexWrap: 'wrap',
+					}}
+				>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Operations (shown)</div>
+						<strong>{numberFormatter.format(visibleOperationRows.length)}</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Hits (1h)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleOperationRows.reduce((sum, row) => sum + row.hits1h, 0)
+							)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Hits (24h)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleOperationRows.reduce((sum, row) => sum + row.hits24h, 0)
+							)}
+						</strong>
+					</div>
+				</div>
+			)}
+
+			<div
+				style={{
+					display: 'flex',
+					gap: '12px',
+					marginBottom: '12px',
+					flexWrap: 'wrap',
+					alignItems: 'center',
+				}}
+			>
+				<input
+					type="text"
+					placeholder={
+						isOperationTab
+							? 'Search operation'
+							: isEntityTab
+								? 'Search entity'
+								: 'Search entity.field'
+					}
+					value={searchTerm}
+					onChange={(event) => setSearchTerm(event.target.value)}
+					style={{ padding: '8px', minWidth: '250px' }}
+				/>
+
+				<label>
+					Top
+					<select
+						value={topLimit}
+						onChange={(event) => setTopLimit(event.target.value)}
+						style={{ marginLeft: '8px' }}
+					>
+						<option value="25">25</option>
+						<option value="50">50</option>
+						<option value="100">100</option>
+						<option value="250">250</option>
+						<option value="all">All</option>
+					</select>
+				</label>
+			</div>
+
+			{(isEntityTab || isPropertyTab) && (
+				<div style={{ width: '100%' }}>
+					<table width="100%">
+						<thead>
+							<tr>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSortChange('entity', 'asc')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										{isEntityTab ? 'Entity' : 'Entity.field'}{' '}
+										{sortBy === 'entity' ? `(${sortDirection})` : ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSortChange('hits1h')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (1h) {sortBy === 'hits1h' ? `(${sortDirection})` : ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSortChange('hits24h')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (24h) {sortBy === 'hits24h' ? `(${sortDirection})` : ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onSortChange('hitsSum')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (total) {sortBy === 'hitsSum' ? `(${sortDirection})` : ''}
+									</button>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{visibleRows.map((row) => {
+								const isSelected = isPropertyTab
+									? selectedEntity === row.entity && selectedProperty === row.property
+									: selectedEntity === row.entity && !selectedProperty;
+
+								return (
+									<tr key={isPropertyTab ? `${row.entity}.${row.property}` : row.entity}>
+										<td>
+											<button
+												type="button"
+												onClick={() => {
+													history.push(
+														isPropertyTab
+															? `/${row.entity}/${row.property}`
+															: `/${row.entity}`
+													);
+												}}
+												style={{
+													textDecoration: 'underline',
+													cursor: 'pointer',
+													color: isSelected ? '#3179e2' : 'black',
+													fontWeight: isSelected ? 'bold' : 'normal',
+													background: 'transparent',
+													border: 0,
+													padding: 0,
+													textAlign: 'left',
+												}}
+											>
+												{isPropertyTab ? `${row.entity}.${row.property}` : row.entity}
+											</button>
+										</td>
+										<td align="center">{numberFormatter.format(Number(row.hits1h) || 0)}</td>
+										<td align="center">{numberFormatter.format(Number(row.hits24h) || 0)}</td>
+										<td align="center">{numberFormatter.format(Number(row.hitsSum) || 0)}</td>
+									</tr>
+								);
+							})}
+						</tbody>
+					</table>
+					{!visibleRows.length && (
+						<Info>
+							{isEntityTab
+								? 'No entities match current filters'
+								: 'No properties match current filters'}
+						</Info>
+					)}
+				</div>
+			)}
+
+			{activeTab === 'operation' && (
+				<div style={{ width: '100%' }}>
+					<table width="100%">
+						<thead>
+							<tr>
+								<th>
+									<button
+										type="button"
+										onClick={() => onOperationSortChange('operation', 'asc')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Operation{' '}
+										{operationSortBy === 'operation'
+											? `(${operationSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onOperationSortChange('hits1h')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (1h){' '}
+										{operationSortBy === 'hits1h'
+											? `(${operationSortDirection})`
+											: ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onOperationSortChange('hits24h')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (24h){' '}
+										{operationSortBy === 'hits24h'
+											? `(${operationSortDirection})`
+											: ''}
+									</button>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{visibleOperationRows.map((row) => (
+								<tr key={`${row.operationType}:${row.operationName}`}>
+									<td>{row.operationType} {row.operationName}</td>
+									<td align="center">{numberFormatter.format(row.hits1h)}</td>
+									<td align="center">{numberFormatter.format(row.hits24h)}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					{!visibleOperationRows.length && (
+						<Info>No operations match current filters</Info>
+					)}
 				</div>
 			)}
 		</div>

--- a/client/analytics/index.jsx
+++ b/client/analytics/index.jsx
@@ -32,7 +32,9 @@ const lineColors = [
 ];
 
 function bucketToTimestamp(bucket) {
-	const parsedMs = Date.parse(bucket.includes('T') ? bucket : `${bucket}T00:00:00Z`);
+	const parsedMs = Date.parse(
+		bucket.includes('T') ? bucket : `${bucket}T00:00:00Z`
+	);
 
 	if (Number.isNaN(parsedMs)) {
 		return null;
@@ -58,8 +60,12 @@ function sortRows(rows, sortBy, sortDirection) {
 
 	sortedRows.sort((rowA, rowB) => {
 		if (sortBy === 'entity') {
-			const keyA = rowA.property ? `${rowA.entity}.${rowA.property}` : rowA.entity;
-			const keyB = rowB.property ? `${rowB.entity}.${rowB.property}` : rowB.entity;
+			const keyA = rowA.property
+				? `${rowA.entity}.${rowA.property}`
+				: rowA.entity;
+			const keyB = rowB.property
+				? `${rowB.entity}.${rowB.property}`
+				: rowB.entity;
 
 			return sortDirection === 'asc'
 				? keyA.localeCompare(keyB)
@@ -70,8 +76,12 @@ function sortRows(rows, sortBy, sortDirection) {
 		const hitsB = hitsByKey(rowB, sortBy);
 
 		if (hitsA === hitsB) {
-			const keyA = rowA.property ? `${rowA.entity}.${rowA.property}` : rowA.entity;
-			const keyB = rowB.property ? `${rowB.entity}.${rowB.property}` : rowB.entity;
+			const keyA = rowA.property
+				? `${rowA.entity}.${rowA.property}`
+				: rowA.entity;
+			const keyB = rowB.property
+				? `${rowB.entity}.${rowB.property}`
+				: rowB.entity;
 			return keyA.localeCompare(keyB);
 		}
 
@@ -96,7 +106,8 @@ function AnalyticsContent() {
 	const [clientSortBy, setClientSortBy] = useState('hits24h');
 	const [clientSortDirection, setClientSortDirection] = useState('desc');
 
-	const { data: fieldsData, loading: fieldsLoading } = useQuery(SCHEMA_FIELDS_USAGE);
+	const { data: fieldsData, loading: fieldsLoading } =
+		useQuery(SCHEMA_FIELDS_USAGE);
 	const { data: entityHitsData, loading: entityHitsLoading } = useQuery(
 		SCHEMA_ENTITY_HITS,
 		{
@@ -233,10 +244,7 @@ function AnalyticsContent() {
 			const key = `${row.operationType}:${row.operationName}`;
 			const label = `${row.operationType} ${row.operationName}`;
 
-			if (
-				normalizedTerm &&
-				!label.toLowerCase().includes(normalizedTerm)
-			) {
+			if (normalizedTerm && !label.toLowerCase().includes(normalizedTerm)) {
 				continue;
 			}
 
@@ -497,7 +505,9 @@ function AnalyticsContent() {
 
 	const onOperationSortChange = (nextSortBy, defaultDirection = 'desc') => {
 		if (operationSortBy === nextSortBy) {
-			setOperationSortDirection(operationSortDirection === 'asc' ? 'desc' : 'asc');
+			setOperationSortDirection(
+				operationSortDirection === 'asc' ? 'desc' : 'asc'
+			);
 			return;
 		}
 
@@ -593,7 +603,7 @@ function AnalyticsContent() {
 								? 'Operation hits (last 24h, 1h buckets)'
 								: isClientTab
 									? 'Client hits (last 24h, 1h buckets)'
-								: 'Entity hits (last 24h, 1h buckets)'}
+									: 'Entity hits (last 24h, 1h buckets)'}
 						</div>
 					</div>
 					{chartSeries.length === 0 ? (
@@ -663,7 +673,10 @@ function AnalyticsContent() {
 						<div>Hits (1h)</div>
 						<strong>
 							{numberFormatter.format(
-								visibleRows.reduce((sum, row) => sum + (Number(row.hits1h) || 0), 0)
+								visibleRows.reduce(
+									(sum, row) => sum + (Number(row.hits1h) || 0),
+									0
+								)
 							)}
 						</strong>
 					</div>
@@ -677,7 +690,10 @@ function AnalyticsContent() {
 						<div>Hits (24h)</div>
 						<strong>
 							{numberFormatter.format(
-								visibleRows.reduce((sum, row) => sum + (Number(row.hits24h) || 0), 0)
+								visibleRows.reduce(
+									(sum, row) => sum + (Number(row.hits24h) || 0),
+									0
+								)
 							)}
 						</strong>
 					</div>
@@ -692,7 +708,10 @@ function AnalyticsContent() {
 							<div>Hits (total)</div>
 							<strong>
 								{numberFormatter.format(
-									visibleRows.reduce((sum, row) => sum + (Number(row.hitsSum) || 0), 0)
+									visibleRows.reduce(
+										(sum, row) => sum + (Number(row.hitsSum) || 0),
+										0
+									)
 								)}
 							</strong>
 						</div>
@@ -717,7 +736,9 @@ function AnalyticsContent() {
 						}}
 					>
 						<div>Operations (shown)</div>
-						<strong>{numberFormatter.format(visibleOperationRows.length)}</strong>
+						<strong>
+							{numberFormatter.format(visibleOperationRows.length)}
+						</strong>
 					</div>
 					<div
 						style={{
@@ -816,9 +837,9 @@ function AnalyticsContent() {
 							? 'Search operation'
 							: isClientTab
 								? 'Search client@version'
-							: isEntityTab
-								? 'Search entity'
-								: 'Search entity.field'
+								: isEntityTab
+									? 'Search entity'
+									: 'Search entity.field'
 					}
 					value={searchTerm}
 					onChange={(event) => setSearchTerm(event.target.value)}
@@ -889,7 +910,8 @@ function AnalyticsContent() {
 											fontWeight: 'bold',
 										}}
 									>
-										Hits (24h) {sortBy === 'hits24h' ? `(${sortDirection})` : ''}
+										Hits (24h){' '}
+										{sortBy === 'hits24h' ? `(${sortDirection})` : ''}
 									</button>
 								</th>
 								<th>
@@ -904,7 +926,8 @@ function AnalyticsContent() {
 											fontWeight: 'bold',
 										}}
 									>
-										Hits (total) {sortBy === 'hitsSum' ? `(${sortDirection})` : ''}
+										Hits (total){' '}
+										{sortBy === 'hitsSum' ? `(${sortDirection})` : ''}
 									</button>
 								</th>
 							</tr>
@@ -912,11 +935,18 @@ function AnalyticsContent() {
 						<tbody>
 							{visibleRows.map((row) => {
 								const isSelected = isPropertyTab
-									? selectedEntity === row.entity && selectedProperty === row.property
+									? selectedEntity === row.entity &&
+										selectedProperty === row.property
 									: selectedEntity === row.entity && !selectedProperty;
 
 								return (
-									<tr key={isPropertyTab ? `${row.entity}.${row.property}` : row.entity}>
+									<tr
+										key={
+											isPropertyTab
+												? `${row.entity}.${row.property}`
+												: row.entity
+										}
+									>
 										<td>
 											<button
 												type="button"
@@ -938,12 +968,20 @@ function AnalyticsContent() {
 													textAlign: 'left',
 												}}
 											>
-												{isPropertyTab ? `${row.entity}.${row.property}` : row.entity}
+												{isPropertyTab
+													? `${row.entity}.${row.property}`
+													: row.entity}
 											</button>
 										</td>
-										<td align="center">{numberFormatter.format(Number(row.hits1h) || 0)}</td>
-										<td align="center">{numberFormatter.format(Number(row.hits24h) || 0)}</td>
-										<td align="center">{numberFormatter.format(Number(row.hitsSum) || 0)}</td>
+										<td align="center">
+											{numberFormatter.format(Number(row.hits1h) || 0)}
+										</td>
+										<td align="center">
+											{numberFormatter.format(Number(row.hits24h) || 0)}
+										</td>
+										<td align="center">
+											{numberFormatter.format(Number(row.hitsSum) || 0)}
+										</td>
 									</tr>
 								);
 							})}
@@ -1023,7 +1061,9 @@ function AnalyticsContent() {
 						<tbody>
 							{visibleOperationRows.map((row) => (
 								<tr key={`${row.operationType}:${row.operationName}`}>
-									<td>{row.operationType} {row.operationName}</td>
+									<td>
+										{row.operationType} {row.operationName}
+									</td>
 									<td align="center">{numberFormatter.format(row.hits1h)}</td>
 									<td align="center">{numberFormatter.format(row.hits24h)}</td>
 								</tr>
@@ -1054,7 +1094,9 @@ function AnalyticsContent() {
 										}}
 									>
 										Client Version{' '}
-										{clientSortBy === 'client' ? `(${clientSortDirection})` : ''}
+										{clientSortBy === 'client'
+											? `(${clientSortDirection})`
+											: ''}
 									</button>
 								</th>
 								<th>
@@ -1069,7 +1111,10 @@ function AnalyticsContent() {
 											fontWeight: 'bold',
 										}}
 									>
-										Hits (1h) {clientSortBy === 'hits1h' ? `(${clientSortDirection})` : ''}
+										Hits (1h){' '}
+										{clientSortBy === 'hits1h'
+											? `(${clientSortDirection})`
+											: ''}
 									</button>
 								</th>
 								<th>
@@ -1084,7 +1129,10 @@ function AnalyticsContent() {
 											fontWeight: 'bold',
 										}}
 									>
-										Hits (24h) {clientSortBy === 'hits24h' ? `(${clientSortDirection})` : ''}
+										Hits (24h){' '}
+										{clientSortBy === 'hits24h'
+											? `(${clientSortDirection})`
+											: ''}
 									</button>
 								</th>
 							</tr>
@@ -1092,7 +1140,9 @@ function AnalyticsContent() {
 						<tbody>
 							{visibleClientRows.map((row) => (
 								<tr key={`${row.clientName}@${row.clientVersion}`}>
-									<td>{row.clientName}@{row.clientVersion}</td>
+									<td>
+										{row.clientName}@{row.clientVersion}
+									</td>
 									<td align="center">{numberFormatter.format(row.hits1h)}</td>
 									<td align="center">{numberFormatter.format(row.hits24h)}</td>
 								</tr>

--- a/client/analytics/index.jsx
+++ b/client/analytics/index.jsx
@@ -11,6 +11,7 @@ import { Chart, LineSeries } from 'lightweight-charts-react-components';
 import SpinnerCenter from '../components/SpinnerCenter';
 import Info from '../components/Info';
 import {
+	SCHEMA_CLIENT_HITS,
 	SCHEMA_ENTITY_HITS,
 	SCHEMA_FIELDS_USAGE,
 	SCHEMA_OPERATION_HITS,
@@ -92,6 +93,8 @@ function AnalyticsContent() {
 	const [sortDirection, setSortDirection] = useState('desc');
 	const [operationSortBy, setOperationSortBy] = useState('hits24h');
 	const [operationSortDirection, setOperationSortDirection] = useState('desc');
+	const [clientSortBy, setClientSortBy] = useState('hits24h');
+	const [clientSortDirection, setClientSortDirection] = useState('desc');
 
 	const { data: fieldsData, loading: fieldsLoading } = useQuery(SCHEMA_FIELDS_USAGE);
 	const { data: entityHitsData, loading: entityHitsLoading } = useQuery(
@@ -105,6 +108,15 @@ function AnalyticsContent() {
 	);
 	const { data: operationHitsData, loading: operationHitsLoading } = useQuery(
 		SCHEMA_OPERATION_HITS,
+		{
+			variables: {
+				granularity: 'HOUR',
+				hours: 24,
+			},
+		}
+	);
+	const { data: clientHitsData, loading: clientHitsLoading } = useQuery(
+		SCHEMA_CLIENT_HITS,
 		{
 			variables: {
 				granularity: 'HOUR',
@@ -137,6 +149,7 @@ function AnalyticsContent() {
 	const isEntityTab = activeTab === 'entity';
 	const isPropertyTab = activeTab === 'property';
 	const isOperationTab = activeTab === 'operation';
+	const isClientTab = activeTab === 'client';
 	const baseRows = isEntityTab ? allEntityRows : allPropertyRows;
 	const filteredRows = useMemo(() => {
 		const normalizedTerm = searchTerm.trim().toLowerCase();
@@ -251,8 +264,50 @@ function AnalyticsContent() {
 		result.sort((a, b) => a.title.localeCompare(b.title));
 		return result;
 	}, [operationHitsData, searchTerm]);
+	const clientChartSeries = useMemo(() => {
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const hitsRows = clientHitsData?.schemaClientHits || [];
+		const byClient = new Map();
 
-	const chartSeries = isOperationTab ? operationChartSeries : entityChartSeries;
+		for (const row of hitsRows) {
+			const clientName = row.clientName || 'unknown';
+			const clientVersion = row.clientVersion || 'unknown';
+			const label = `${clientName}@${clientVersion}`;
+
+			if (normalizedTerm && !label.toLowerCase().includes(normalizedTerm)) {
+				continue;
+			}
+
+			const time = bucketToTimestamp(row.bucket);
+			if (time === null) {
+				continue;
+			}
+
+			if (!byClient.has(label)) {
+				byClient.set(label, { title: label, data: [] });
+			}
+
+			byClient.get(label).data.push({
+				time,
+				value: Number(row.hits) || 0,
+			});
+		}
+
+		const result = [];
+		for (const [key, series] of byClient.entries()) {
+			series.data.sort((a, b) => a.time - b.time);
+			result.push({ key, title: series.title, data: series.data });
+		}
+
+		result.sort((a, b) => a.title.localeCompare(b.title));
+		return result;
+	}, [clientHitsData, searchTerm]);
+
+	const chartSeries = isOperationTab
+		? operationChartSeries
+		: isClientTab
+			? clientChartSeries
+			: entityChartSeries;
 
 	const operationRows = useMemo(() => {
 		const byOperation = new Map();
@@ -332,16 +387,101 @@ function AnalyticsContent() {
 
 		return sortedOperationRows.slice(0, parsedTopLimit);
 	}, [sortedOperationRows, topLimit]);
+	const clientRows = useMemo(() => {
+		const byClient = new Map();
+		const normalizedTerm = searchTerm.trim().toLowerCase();
+		const nowSec = Math.floor(Date.now() / 1000);
+		const last1hCutoffSec = nowSec - 60 * 60;
+		const rows = clientHitsData?.schemaClientHits || [];
+
+		for (const row of rows) {
+			const clientName = row.clientName || 'unknown';
+			const clientVersion = row.clientVersion || 'unknown';
+			const label = `${clientName}@${clientVersion}`;
+
+			if (normalizedTerm && !label.toLowerCase().includes(normalizedTerm)) {
+				continue;
+			}
+
+			const key = label;
+			const bucketSec = bucketToTimestamp(row.bucket);
+			const hits = Number(row.hits) || 0;
+
+			if (!byClient.has(key)) {
+				byClient.set(key, {
+					clientName,
+					clientVersion,
+					hits1h: 0,
+					hits24h: 0,
+				});
+			}
+
+			const entry = byClient.get(key);
+			entry.hits24h += hits;
+
+			if (bucketSec !== null && bucketSec >= last1hCutoffSec) {
+				entry.hits1h += hits;
+			}
+		}
+
+		return Array.from(byClient.values());
+	}, [clientHitsData, searchTerm]);
+
+	const sortedClientRows = useMemo(() => {
+		const rows = [...clientRows];
+
+		rows.sort((rowA, rowB) => {
+			if (clientSortBy === 'client') {
+				const labelA = `${rowA.clientName}@${rowA.clientVersion}`;
+				const labelB = `${rowB.clientName}@${rowB.clientVersion}`;
+
+				return clientSortDirection === 'asc'
+					? labelA.localeCompare(labelB)
+					: labelB.localeCompare(labelA);
+			}
+
+			const hitsA = clientSortBy === 'hits1h' ? rowA.hits1h : rowA.hits24h;
+			const hitsB = clientSortBy === 'hits1h' ? rowB.hits1h : rowB.hits24h;
+
+			if (hitsA === hitsB) {
+				const labelA = `${rowA.clientName}@${rowA.clientVersion}`;
+				const labelB = `${rowB.clientName}@${rowB.clientVersion}`;
+				return labelA.localeCompare(labelB);
+			}
+
+			return clientSortDirection === 'asc' ? hitsA - hitsB : hitsB - hitsA;
+		});
+
+		return rows;
+	}, [clientRows, clientSortBy, clientSortDirection]);
+
+	const visibleClientRows = useMemo(() => {
+		if (topLimit === 'all') {
+			return sortedClientRows;
+		}
+
+		const parsedTopLimit = Number(topLimit);
+		if (!parsedTopLimit || parsedTopLimit <= 0) {
+			return sortedClientRows;
+		}
+
+		return sortedClientRows.slice(0, parsedTopLimit);
+	}, [sortedClientRows, topLimit]);
 
 	if (
 		fieldsLoading ||
 		entityHitsLoading ||
-		operationHitsLoading
+		operationHitsLoading ||
+		clientHitsLoading
 	) {
 		return <SpinnerCenter />;
 	}
 
-	if (!allPropertyRows.length) {
+	if (
+		!allPropertyRows.length &&
+		!(operationHitsData?.schemaOperationHits || []).length &&
+		!(clientHitsData?.schemaClientHits || []).length
+	) {
 		return <Info>No usage data logged yet</Info>;
 	}
 
@@ -363,6 +503,16 @@ function AnalyticsContent() {
 
 		setOperationSortBy(nextSortBy);
 		setOperationSortDirection(defaultDirection);
+	};
+
+	const onClientSortChange = (nextSortBy, defaultDirection = 'desc') => {
+		if (clientSortBy === nextSortBy) {
+			setClientSortDirection(clientSortDirection === 'asc' ? 'desc' : 'asc');
+			return;
+		}
+
+		setClientSortBy(nextSortBy);
+		setClientSortDirection(defaultDirection);
 	};
 
 	return (
@@ -393,6 +543,19 @@ function AnalyticsContent() {
 					}}
 				>
 					Properties
+				</button>
+				<button
+					type="button"
+					onClick={() => setActiveTab('client')}
+					style={{
+						padding: '8px 12px',
+						border: '1px solid #DDDDDD',
+						background: isClientTab ? '#F0F6FF' : '#FFFFFF',
+						cursor: 'pointer',
+						fontWeight: isClientTab ? 'bold' : 'normal',
+					}}
+				>
+					Clients
 				</button>
 				<button
 					type="button"
@@ -428,6 +591,8 @@ function AnalyticsContent() {
 						<div style={{ fontWeight: 'bold' }}>
 							{isOperationTab
 								? 'Operation hits (last 24h, 1h buckets)'
+								: isClientTab
+									? 'Client hits (last 24h, 1h buckets)'
 								: 'Entity hits (last 24h, 1h buckets)'}
 						</div>
 					</div>
@@ -585,6 +750,56 @@ function AnalyticsContent() {
 				</div>
 			)}
 
+			{isClientTab && (
+				<div
+					style={{
+						display: 'flex',
+						gap: '12px',
+						marginBottom: '16px',
+						flexWrap: 'wrap',
+					}}
+				>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Client Versions (shown)</div>
+						<strong>{numberFormatter.format(visibleClientRows.length)}</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Hits (1h)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleClientRows.reduce((sum, row) => sum + row.hits1h, 0)
+							)}
+						</strong>
+					</div>
+					<div
+						style={{
+							border: '1px solid #EEEEEE',
+							padding: '12px 16px',
+							minWidth: '150px',
+						}}
+					>
+						<div>Hits (24h)</div>
+						<strong>
+							{numberFormatter.format(
+								visibleClientRows.reduce((sum, row) => sum + row.hits24h, 0)
+							)}
+						</strong>
+					</div>
+				</div>
+			)}
+
 			<div
 				style={{
 					display: 'flex',
@@ -599,6 +814,8 @@ function AnalyticsContent() {
 					placeholder={
 						isOperationTab
 							? 'Search operation'
+							: isClientTab
+								? 'Search client@version'
 							: isEntityTab
 								? 'Search entity'
 								: 'Search entity.field'
@@ -815,6 +1032,75 @@ function AnalyticsContent() {
 					</table>
 					{!visibleOperationRows.length && (
 						<Info>No operations match current filters</Info>
+					)}
+				</div>
+			)}
+
+			{isClientTab && (
+				<div style={{ width: '100%' }}>
+					<table width="100%">
+						<thead>
+							<tr>
+								<th>
+									<button
+										type="button"
+										onClick={() => onClientSortChange('client', 'asc')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Client Version{' '}
+										{clientSortBy === 'client' ? `(${clientSortDirection})` : ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onClientSortChange('hits1h')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (1h) {clientSortBy === 'hits1h' ? `(${clientSortDirection})` : ''}
+									</button>
+								</th>
+								<th>
+									<button
+										type="button"
+										onClick={() => onClientSortChange('hits24h')}
+										style={{
+											cursor: 'pointer',
+											background: 'transparent',
+											border: 0,
+											padding: 0,
+											fontWeight: 'bold',
+										}}
+									>
+										Hits (24h) {clientSortBy === 'hits24h' ? `(${clientSortDirection})` : ''}
+									</button>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{visibleClientRows.map((row) => (
+								<tr key={`${row.clientName}@${row.clientVersion}`}>
+									<td>{row.clientName}@{row.clientVersion}</td>
+									<td align="center">{numberFormatter.format(row.hits1h)}</td>
+									<td align="center">{numberFormatter.format(row.hits24h)}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					{!visibleClientRows.length && (
+						<Info>No client versions match current filters</Info>
 					)}
 				</div>
 			)}

--- a/client/components/GlobalSearch.jsx
+++ b/client/components/GlobalSearch.jsx
@@ -11,7 +11,25 @@ const useStyles = makeStyles(() => ({
 	input: {
 		color: '#FFFFFF',
 	},
+	label: {
+		color: 'rgba(255, 255, 255, 0.85)',
+	},
 	root: {
+		'& .MuiFilledInput-root': {
+			backgroundColor: 'rgba(255, 255, 255, 0.18)',
+		},
+		'& .MuiFilledInput-root:hover': {
+			backgroundColor: 'rgba(255, 255, 255, 0.24)',
+		},
+		'& .MuiFilledInput-root.Mui-focused': {
+			backgroundColor: 'rgba(255, 255, 255, 0.3)',
+		},
+		'& .MuiFilledInput-root:before': {
+			borderBottomColor: 'rgba(255, 255, 255, 0.55)',
+		},
+		'& .MuiFilledInput-root:hover:not(.Mui-disabled):before': {
+			borderBottomColor: 'rgba(255, 255, 255, 0.8)',
+		},
 		'& label.Mui-focused': {
 			color: focusedColor,
 		},
@@ -120,6 +138,7 @@ const GlobalSearch = () => {
 			<TextField
 				className={classes.root}
 				inputProps={{ className: classes.input }}
+				InputLabelProps={{ className: classes.label }}
 				size={'small'}
 				inputRef={setTextInputRef}
 				// inputRef={(input) => input?.focus()}

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -6,7 +6,6 @@ import {
 	SchemaIcon,
 	ServicesIcon,
 	AnalyticsIcon,
-	ClientsIcon,
 	PersistedQueriesIcon,
 	LogsIcon,
 	ChangeLogIcon,
@@ -15,7 +14,6 @@ import Services from '../schema';
 import Analytics from '../analytics';
 import SupergraphSchema from '../supergraph';
 import PersistedQueries from '../persisted-queries';
-import Clients from '../clients';
 import SchemaChangeLog from '../schema-change-log';
 
 import ServicesTab from '../schema/Tab';
@@ -40,12 +38,6 @@ const UITabs = [
 		icon: <AnalyticsIcon />,
 		href: '/analytics',
 		component: Analytics,
-	},
-	{
-		Title: <span>Clients</span>,
-		icon: <ClientsIcon />,
-		href: '/clients',
-		component: Clients,
 	},
 	{
 		Title: <PersistedQueriesTab />,

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -9,12 +9,14 @@ import {
 	ClientsIcon,
 	PersistedQueriesIcon,
 	LogsIcon,
+	ChangeLogIcon,
 } from './MenuIcons';
 import Services from '../schema';
 import Analytics from '../analytics';
 import SupergraphSchema from '../supergraph';
 import PersistedQueries from '../persisted-queries';
 import Clients from '../clients';
+import SchemaChangeLog from '../schema-change-log';
 
 import ServicesTab from '../schema/Tab';
 import PersistedQueriesTab from '../persisted-queries/Tab';
@@ -50,6 +52,12 @@ const UITabs = [
 		icon: <PersistedQueriesIcon />,
 		href: '/persisted-queries',
 		component: PersistedQueries,
+	},
+	{
+		Title: <span>Change Log</span>,
+		icon: <ChangeLogIcon />,
+		href: '/changes',
+		component: SchemaChangeLog,
 	},
 	{
 		Title: <span>Logs</span>,
@@ -88,6 +96,7 @@ const Main = () => {
 			<main className="registry-content">
 				<Switch>
 					<Redirect exact from="/" to="/schema" />
+					<Redirect exact from="/schema-change-log" to="/changes" />
 					{UITabs.map((tab, index) => (
 						<Route
 							key={tab.href}

--- a/client/components/MenuIcons.jsx
+++ b/client/components/MenuIcons.jsx
@@ -80,3 +80,16 @@ export function LogsIcon() {
 		</svg>
 	);
 }
+
+export function ChangeLogIcon() {
+	return (
+		<svg {...iconProps}>
+			<path d="M6 6h12" />
+			<path d="M6 12h12" />
+			<path d="M6 18h12" />
+			<circle cx="4" cy="6" r="1" fill="currentColor" stroke="none" />
+			<circle cx="4" cy="12" r="1" fill="currentColor" stroke="none" />
+			<circle cx="4" cy="18" r="1" fill="currentColor" stroke="none" />
+		</svg>
+	);
+}

--- a/client/logs/index.jsx
+++ b/client/logs/index.jsx
@@ -7,9 +7,96 @@ import SpinnerCenter from '../components/SpinnerCenter';
 import { LOGS } from '../utils/queries';
 import Info from '../components/Info';
 
-import { format } from 'date-fns';
+const LOG_NOISE_PATTERNS = [
+	/^Validating schema\. Got services schemas from DB transaction\.\.$/i,
+	/^Composing graph\. Got services schemas from DB transaction\.\.$/i,
+];
+const ANSI_COLOR_CODE_REGEX = new RegExp(
+	`${String.fromCharCode(27)}\\[[0-9;]*m`,
+	'g'
+);
 
-export default function PersistedQueries() {
+function stripAnsi(value) {
+	if (typeof value !== 'string') {
+		return '';
+	}
+
+	return value.replaceAll(ANSI_COLOR_CODE_REGEX, '');
+}
+
+function normalizeMessage(message) {
+	if (typeof message === 'string') {
+		return stripAnsi(message);
+	}
+
+	if (Array.isArray(message)) {
+		return message
+			.map((entry) => {
+				if (!entry || typeof entry !== 'object') {
+					return '';
+				}
+
+				const code = entry.extensions?.code
+					? ` (${entry.extensions.code})`
+					: '';
+				return `${stripAnsi(entry.message || '')}${code}`;
+			})
+			.filter(Boolean)
+			.join('; ');
+	}
+
+	if (message && typeof message === 'object') {
+		return stripAnsi(JSON.stringify(message));
+	}
+
+	return '';
+}
+
+function normalizeLevel(level) {
+	const cleaned = stripAnsi(level || '').toLowerCase();
+
+	if (cleaned.includes('error')) {
+		return 'ERROR';
+	}
+
+	if (cleaned.includes('warn')) {
+		return 'WARN';
+	}
+
+	if (cleaned.includes('debug')) {
+		return 'DEBUG';
+	}
+
+	return 'INFO';
+}
+
+function levelColor(level) {
+	switch (level) {
+		case 'ERROR':
+			return '#b91c1c';
+		case 'WARN':
+			return '#a16207';
+		case 'DEBUG':
+			return '#4b5563';
+		default:
+			return '#0f766e';
+	}
+}
+
+function formatTimestamp(timestamp) {
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) {
+		return '';
+	}
+
+	return date.toISOString().slice(0, 23).replace('T', ' ');
+}
+
+function shouldHideMessage(message) {
+	return LOG_NOISE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export default function Logs() {
 	const { loading, data } = useQuery(LOGS);
 
 	if (loading) {
@@ -20,40 +107,86 @@ export default function PersistedQueries() {
 		return <Info>No Logs yet</Info>;
 	}
 
+	const rows = data.logs
+		.map((row) => ({
+			timestamp: formatTimestamp(row.timestamp),
+			level: normalizeLevel(row.level),
+			message: normalizeMessage(row.message),
+		}))
+		.filter((row) => row.message && row.timestamp)
+		.filter((row) => !shouldHideMessage(row.message))
+		.filter(
+			(row, index, allRows) =>
+				index === 0 ||
+				!(
+					allRows[index - 1].level === row.level &&
+					allRows[index - 1].message === row.message
+				)
+		);
+
+	if (!rows.length) {
+		return <Info>No relevant logs for the selected period</Info>;
+	}
+
 	return (
 		<div>
 			<Info>
-				You can see last schema-registry logs. Useful in case of validation
-				errors
+				Recent schema-registry backend logs (UTC, latest first)
 			</Info>
 
-			<table>
-				{data.logs.map((row, i) => (
-					<tr key={i}>
-						<td
-							style={{
-								borderRight: '1px solid gray',
-								padding: '0 10px',
-							}}
-						>
-							{format(new Date(row.timestamp), 'd MMMM / HH:mm', {
-								timeZone: 'UTC',
-							})}
-						</td>
-						<td>{row.level.indexOf('error') > 0 ? '🔴' : 'ℹ️'} </td>
-						<td>
-							{typeof row.message === 'string' ? row.message : ''}
-							{typeof row.message === 'object' &&
-								row.message.map((row, j) => {
-									return (
-										<div key={j}>
-											{row.message}({row.extensions.code})
-										</div>
-									);
-								})}
-						</td>
+			<table
+				style={{
+					width: '100%',
+					borderCollapse: 'collapse',
+					fontFamily:
+						'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+					fontSize: 13,
+				}}
+			>
+				<thead>
+					<tr>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>
+							TIMESTAMP (UTC)
+						</th>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>LEVEL</th>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>MESSAGE</th>
 					</tr>
-				))}
+				</thead>
+				<tbody>
+					{rows.map((row, index) => (
+						<tr key={`${row.timestamp}-${index}`}>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									whiteSpace: 'nowrap',
+								}}
+							>
+								{row.timestamp}
+							</td>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									color: levelColor(row.level),
+									fontWeight: 600,
+									whiteSpace: 'nowrap',
+								}}
+							>
+								{row.level}
+							</td>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									wordBreak: 'break-word',
+								}}
+							>
+								{row.message}
+							</td>
+						</tr>
+					))}
+				</tbody>
 			</table>
 		</div>
 	);

--- a/client/logs/index.jsx
+++ b/client/logs/index.jsx
@@ -130,9 +130,7 @@ export default function Logs() {
 
 	return (
 		<div>
-			<Info>
-				Recent schema-registry backend logs (UTC, latest first)
-			</Info>
+			<Info>Recent schema-registry backend logs (UTC, latest first)</Info>
 
 			<table
 				style={{

--- a/client/schema-change-log/index.jsx
+++ b/client/schema-change-log/index.jsx
@@ -52,9 +52,7 @@ export default function SchemaChangeLog() {
 
 	return (
 		<div>
-			<Info>
-				Chronological schema changes across subgraphs (latest first)
-			</Info>
+			<Info>Chronological schema changes across subgraphs (latest first)</Info>
 			<table
 				style={{
 					width: '100%',

--- a/client/schema-change-log/index.jsx
+++ b/client/schema-change-log/index.jsx
@@ -1,0 +1,135 @@
+import { useQuery } from '@apollo/client';
+import { Link } from 'react-router-dom';
+import { format } from 'date-fns';
+
+import SpinnerCenter from '../components/SpinnerCenter';
+import Info from '../components/Info';
+import { SCHEMA_CHANGE_LOG } from '../utils/queries';
+
+function formatDate(value) {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return '';
+	}
+
+	return format(date, 'yyyy-MM-dd');
+}
+
+function formatTime(value) {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return '';
+	}
+
+	return format(date, 'HH:mm:ss');
+}
+
+function shortHash(hash) {
+	if (!hash) {
+		return 'n/a';
+	}
+
+	return hash.slice(0, 8);
+}
+
+export default function SchemaChangeLog() {
+	const { loading, data } = useQuery(SCHEMA_CHANGE_LOG, {
+		variables: {
+			limit: 500,
+			offset: 0,
+		},
+	});
+
+	if (loading) {
+		return <SpinnerCenter />;
+	}
+
+	const rows = data?.schemaChangeLog || [];
+
+	if (!rows.length) {
+		return <Info>No schema changes found.</Info>;
+	}
+
+	return (
+		<div>
+			<Info>
+				Chronological schema changes across subgraphs (latest first)
+			</Info>
+			<table
+				style={{
+					width: '100%',
+					borderCollapse: 'collapse',
+					fontFamily:
+						'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+					fontSize: 13,
+				}}
+			>
+				<thead>
+					<tr>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>DATE</th>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>TIME</th>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>SUBGRAPH</th>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>SCHEMA</th>
+						<th style={{ textAlign: 'left', padding: '6px 10px' }}>CHANGE</th>
+					</tr>
+				</thead>
+				<tbody>
+					{rows.map((row, index) => (
+						<tr
+							key={`${row.schemaId}-${row.changeType}-${index}`}
+							style={{ verticalAlign: 'top' }}
+						>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									whiteSpace: 'nowrap',
+								}}
+							>
+								{formatDate(row.addedTime)}
+							</td>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									whiteSpace: 'nowrap',
+								}}
+							>
+								{formatTime(row.addedTime)}
+							</td>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									whiteSpace: 'nowrap',
+								}}
+							>
+								{row.serviceName}
+							</td>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									whiteSpace: 'nowrap',
+								}}
+							>
+								<Link to={`/services/${row.serviceName}/${row.schemaId}/sdl`}>
+									{shortHash(row.schemaUUID)}
+								</Link>
+							</td>
+							<td
+								style={{
+									borderTop: '1px solid #e5e7eb',
+									padding: '6px 10px',
+									wordBreak: 'break-word',
+								}}
+							>
+								{row.change}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/client/schema/service-details/ServiceSchemas.jsx
+++ b/client/schema/service-details/ServiceSchemas.jsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@apollo/client';
+import { useHistory, useParams } from 'react-router-dom';
 
 import SpinnerCenter from '../../components/SpinnerCenter';
 import { SchemaListColumn, FlexRow } from '../styled';
@@ -11,6 +12,23 @@ import { SERVICE_SCHEMAS } from '../../utils/queries';
 const ServiceSchemas = ({ service }) => {
 	const [filterValue] = useState('');
 	const { loading, data, error } = useServiceSchemas(service.id, filterValue);
+	const history = useHistory();
+	const { serviceName, schemaId } = useParams();
+
+	useEffect(() => {
+		if (!data?.service?.schemas?.length || !serviceName) {
+			return;
+		}
+
+		const selectedSchemaId = parseInt(schemaId, 10);
+		const hasSelectedSchema = data.service.schemas.some(
+			(schema) => schema.id === selectedSchemaId
+		);
+
+		if (!hasSelectedSchema) {
+			history.replace(`/${serviceName}/${data.service.schemas[0].id}/sdl`);
+		}
+	}, [data, history, schemaId, serviceName]);
 
 	const content = loading ? (
 		<SpinnerCenter />

--- a/client/schema/service-details/UsageTab/graph.jsx
+++ b/client/schema/service-details/UsageTab/graph.jsx
@@ -1,12 +1,26 @@
-import { Lines, Chart, Dots } from 'rumble-charts';
+import { Chart, LineSeries } from 'lightweight-charts-react-components';
 import { useQuery } from '@apollo/client';
+import { useState } from 'react';
 
 import { SCHEMA_USAGE_SDL } from '../../../utils/queries';
 import SpinnerCenter from '../../../components/SpinnerCenter';
 
+function bucketToTimestamp(bucket) {
+	const parsedMs = bucket.includes('T')
+		? Date.parse(bucket)
+		: Date.parse(`${bucket}T00:00:00Z`);
+
+	if (Number.isNaN(parsedMs)) {
+		return null;
+	}
+
+	return Math.floor(parsedMs / 1000);
+}
+
 export default function UsageTabGraph({ entity, property }) {
+	const [granularity, setGranularity] = useState('HOUR');
 	const { data, loading } = useQuery(SCHEMA_USAGE_SDL, {
-		variables: { entity, property },
+		variables: { entity, property, granularity },
 	});
 
 	if (loading) {
@@ -46,11 +60,11 @@ export default function UsageTabGraph({ entity, property }) {
 
 	const clientHits = {};
 
-	let max = 0;
+	const nowSec = Math.floor(Date.now() / 1000);
+	const last24HoursCutoffSec = nowSec - 24 * 60 * 60;
 
 	for (const hit of data.schemaPropertyHitsByClient) {
-		// key is needed to draw different lines, depending on segmentation
-		const key = hit?.clientName;
+		const key = hit?.clientName || 'unknown';
 
 		if (!clientHits[key]) {
 			clientHits[key] = {
@@ -59,29 +73,87 @@ export default function UsageTabGraph({ entity, property }) {
 			};
 		}
 
-		const [, month, day] = hit.day.split('-');
+		const time = bucketToTimestamp(hit.bucket);
 
-		clientHits[key].data.push([
-			month * 30 + day, // x on the graph - just convert days of the year into pixels
-			hit.hits, // y on the graph
-		]);
-
-		if (hit.hits > max) {
-			max = hit.hits; // pick max hits for the graph
+		if (time === null) {
+			continue;
 		}
+
+		if (granularity === 'HOUR' && time < last24HoursCutoffSec) {
+			continue;
+		}
+
+		clientHits[key].data.push({
+			time,
+			value: Number(hit.hits),
+		});
 	}
 
 	const series = [];
+	const colors = [
+		'#1E88E5',
+		'#D81B60',
+		'#43A047',
+		'#FB8C00',
+		'#8E24AA',
+		'#00ACC1',
+	];
 
 	for (const [, clientHitsData] of Object.entries(clientHits)) {
+		clientHitsData.data.sort((hitA, hitB) => hitA.time - hitB.time);
+		clientHitsData.color = colors[series.length % colors.length];
 		series.push(clientHitsData);
 	}
 
 	return (
 		<div>
-			<Chart width={450} height={200} series={series} minY={0} maxY={max * 1.3}>
-				<Lines />
-				<Dots />
+			<div style={{ margin: '8px 0' }}>
+				<label>
+					Granularity
+					<select
+						value={granularity}
+						onChange={(event) => setGranularity(event.target.value)}
+						style={{ marginLeft: '8px' }}
+					>
+						<option value="HOUR">Hourly (24h window)</option>
+						<option value="DAY">Daily</option>
+					</select>
+				</label>
+			</div>
+
+			<Chart
+				options={{
+					layout: {
+						attributionLogo: false,
+					},
+					height: 240,
+					timeScale: {
+						timeVisible: granularity === 'HOUR',
+						secondsVisible: false,
+					},
+					rightPriceScale: {
+						autoScale: true,
+					},
+				}}
+				containerProps={{
+					style: {
+						width: '100%',
+						minWidth: '420px',
+						height: '240px',
+					},
+				}}
+			>
+				{series.map((seriesRow) => (
+					<LineSeries
+						key={seriesRow.name}
+						data={seriesRow.data}
+						options={{
+							color: seriesRow.color,
+							lineWidth: 2,
+							title: seriesRow.name,
+						}}
+					/>
+				))}
 			</Chart>
 
 			<table style={{ margin: '0 auto' }}>
@@ -95,10 +167,12 @@ export default function UsageTabGraph({ entity, property }) {
 				<tbody>
 					{data.schemaPropertyHitsByClient.map((hit) => {
 						return (
-							<tr key={hit.clientName}>
+							<tr
+								key={`${hit.clientName || 'unknown'}-${hit.bucket}-${hit.hits}`}
+							>
 								<td>{hit.clientName}</td>
 								<td>{hit.hits}</td>
-								<td>{hit.day}</td>
+								<td>{hit.bucket}</td>
 							</tr>
 						);
 					})}

--- a/client/schema/service-details/VersionsList.jsx
+++ b/client/schema/service-details/VersionsList.jsx
@@ -3,10 +3,19 @@ import { formatDistance } from 'date-fns';
 
 import { EntryGrid } from '../../components/styled';
 import { FlexRow, VersionRow, VersionTag } from '../styled';
-import DeveloperModeIcon from '@material-ui/icons/DeveloperMode';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { List, ListItem, Tooltip } from '@material-ui/core';
 import VersionCharDelta from './VersionCharDelta';
+
+const VERSION_PREVIEW_LENGTH = 6;
+
+function getVersionPreview(version) {
+	if (!version) {
+		return '';
+	}
+
+	return version.slice(0, VERSION_PREVIEW_LENGTH);
+}
 
 const VersionsList = ({ service }) => {
 	const { serviceName, schemaId } = useParams();
@@ -22,9 +31,10 @@ const VersionsList = ({ service }) => {
 			{service.schemas.map((schema) => {
 				const today = new Date();
 				const date = new Date(schema.addedTime);
+				const versionPreview = getVersionPreview(schema.UUID);
 				const icon = schema.isDev ? (
 					<Tooltip placement="right" title="Registered by service in dev mode">
-						<DeveloperModeIcon />
+						<span role="img" aria-label="Registered by service in dev mode">🛠️</span>
 					</Tooltip>
 				) : (
 					<ChevronRightIcon />
@@ -41,7 +51,7 @@ const VersionsList = ({ service }) => {
 						<EntryGrid>
 							<div>
 								<FlexRow>
-									<VersionTag>{schema.UUID}</VersionTag>
+									<VersionTag title={schema.UUID}>{versionPreview}</VersionTag>
 								</FlexRow>
 								<VersionRow selected={selectedSchema === schema.id}>
 									<VersionCharDelta

--- a/client/schema/service-details/VersionsList.jsx
+++ b/client/schema/service-details/VersionsList.jsx
@@ -34,7 +34,9 @@ const VersionsList = ({ service }) => {
 				const versionPreview = getVersionPreview(schema.UUID);
 				const icon = schema.isDev ? (
 					<Tooltip placement="right" title="Registered by service in dev mode">
-						<span role="img" aria-label="Registered by service in dev mode">🛠️</span>
+						<span role="img" aria-label="Registered by service in dev mode">
+							🛠️
+						</span>
 					</Tooltip>
 				) : (
 					<ChevronRightIcon />

--- a/client/schema/service-list/index.jsx
+++ b/client/schema/service-list/index.jsx
@@ -8,6 +8,7 @@ import { useRouteMatch, useHistory } from 'react-router-dom';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import Info from '../../components/Info';
+import { ServiceLabel, ServiceStatusDot } from './styled';
 
 const ServiceList = () => {
 	const { data } = useQuery(SERVICES_LIST);
@@ -16,17 +17,36 @@ const ServiceList = () => {
 		return (
 			<ServiceListColumnEmpty>
 				<Info>
-					No federated services found
+					No federated services found.
 					<br />
-					Use{' '}
+					Register your first service with{' '}
 					<a
 						href={
 							'https://github.com/pipedrive/graphql-schema-registry#-post-schemapush'
 						}
 					>
 						POST /schema/push
-					</a>{' '}
-					to add one
+					</a>
+					:
+					<pre
+						style={{
+							margin: '8px 0 0',
+							padding: 10,
+							backgroundColor: 'rgba(0, 0, 0, 0.25)',
+							whiteSpace: 'pre-wrap',
+							wordBreak: 'break-word',
+						}}
+					>
+						{`curl -X POST http://localhost:6001/schema/push \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "name": "products",
+    "kind": "federated",
+    "url": "http://localhost:4001/graphql",
+    "typeDefs": "type Query { products: [Product!]! } type Product @key(fields: \\"id\\") { id: ID! name: String! }",
+    "version": "v1"
+  }'`}
+					</pre>
 				</Info>
 			</ServiceListColumnEmpty>
 		);
@@ -45,7 +65,19 @@ const ServiceList = () => {
 						onClick={() => history.push(`/${service.name}`)}
 						selected={service.name === match?.params?.serviceName}
 					>
-						<ListItemText primary={service.name} />
+						<ListItemText
+							primary={
+								<ServiceLabel>
+									<ServiceStatusDot
+										status={service.healthStatus}
+										title={
+											service.healthStatus === 'UP' ? 'Service is up' : 'Service is down'
+										}
+									/>
+									<span>{service.name}</span>
+								</ServiceLabel>
+							}
+						/>
 						<ListItemIcon>
 							<ChevronRightIcon />
 						</ListItemIcon>

--- a/client/schema/service-list/index.jsx
+++ b/client/schema/service-list/index.jsx
@@ -71,7 +71,9 @@ const ServiceList = () => {
 									<ServiceStatusDot
 										status={service.healthStatus}
 										title={
-											service.healthStatus === 'UP' ? 'Service is up' : 'Service is down'
+											service.healthStatus === 'UP'
+												? 'Service is up'
+												: 'Service is down'
 										}
 									/>
 									<span>{service.name}</span>

--- a/client/schema/service-list/styled.js
+++ b/client/schema/service-list/styled.js
@@ -9,3 +9,17 @@ export const ServiceBlock = styled.div`
 		color: ${({ selected }) => (selected ? 'white' : colors.black.hex32)};
 	}
 `;
+
+export const ServiceLabel = styled.div`
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+`;
+
+export const ServiceStatusDot = styled.span`
+	width: 8px;
+	height: 8px;
+	border-radius: 999px;
+	flex-shrink: 0;
+	background-color: ${({ status }) => (status === 'UP' ? '#2e7d32' : '#9e9e9e')};
+`;

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -152,6 +152,17 @@ export const SCHEMA_OPERATION_HITS = gql`
 	}
 `;
 
+export const SCHEMA_CLIENT_HITS = gql`
+	query getSchemaClientHits($granularity: UsageGranularity, $hours: Int) {
+		schemaClientHits(granularity: $granularity, hours: $hours) {
+			clientName
+			clientVersion
+			bucket
+			hits
+		}
+	}
+`;
+
 export const SCHEMA_TOP_OPERATIONS = gql`
 	query getSchemaTopOperations($hours: Int, $limit: Int) {
 		schemaTopOperations(hours: $hours, limit: $limit) {

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -33,6 +33,7 @@ export const SERVICES_LIST = gql`
 		services {
 			id
 			name
+			healthStatus
 		}
 	}
 `;
@@ -100,10 +101,19 @@ export const SCHEMA_SDL = gql`
 	}
 `;
 export const SCHEMA_USAGE_SDL = gql`
-	query getSchemaUsageSDL($entity: String!, $property: String!) {
-		schemaPropertyHitsByClient(entity: $entity, property: $property) {
+	query getSchemaUsageSDL(
+		$entity: String!
+		$property: String!
+		$granularity: UsageGranularity
+	) {
+		schemaPropertyHitsByClient(
+			entity: $entity
+			property: $property
+			granularity: $granularity
+		) {
 			hits
 			day
+			bucket
 			clientName
 		}
 	}
@@ -115,6 +125,39 @@ export const SCHEMA_FIELDS_USAGE = gql`
 			entity
 			property
 			hitsSum
+			hits1h
+			hits24h
+		}
+	}
+`;
+
+export const SCHEMA_ENTITY_HITS = gql`
+	query getSchemaEntityHits($granularity: UsageGranularity, $hours: Int) {
+		schemaEntityHits(granularity: $granularity, hours: $hours) {
+			entity
+			bucket
+			hits
+		}
+	}
+`;
+
+export const SCHEMA_OPERATION_HITS = gql`
+	query getSchemaOperationHits($granularity: UsageGranularity, $hours: Int) {
+		schemaOperationHits(granularity: $granularity, hours: $hours) {
+			operationName
+			operationType
+			bucket
+			hits
+		}
+	}
+`;
+
+export const SCHEMA_TOP_OPERATIONS = gql`
+	query getSchemaTopOperations($hours: Int, $limit: Int) {
+		schemaTopOperations(hours: $hours, limit: $limit) {
+			operationName
+			operationType
+			hits
 		}
 	}
 `;
@@ -144,6 +187,19 @@ export const CLIENT_VERSION_PERSISTED_QUERIES = gql`
 export const LOGS = gql`
 	query getLogs {
 		logs
+	}
+`;
+
+export const SCHEMA_CHANGE_LOG = gql`
+	query getSchemaChangeLog($limit: Int, $offset: Int, $serviceName: String) {
+		schemaChangeLog(limit: $limit, offset: $offset, serviceName: $serviceName) {
+			serviceName
+			schemaId
+			schemaUUID
+			addedTime
+			changeType
+			change
+		}
 	}
 `;
 

--- a/client/utils/usePrism.jsx
+++ b/client/utils/usePrism.jsx
@@ -1,5 +1,6 @@
 import { useRef, useLayoutEffect } from 'react';
 import Prism from 'prismjs';
+import 'prismjs/components/prism-graphql';
 
 function usePrism(code) {
 	const ref = useRef();

--- a/migrations/20260310100000_add_schema_hit_hourly.sql
+++ b/migrations/20260310100000_add_schema_hit_hourly.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS schema_hit_hourly (
+    id BIGSERIAL PRIMARY KEY,
+    client_id BIGINT NULL REFERENCES clients(id) ON DELETE CASCADE,
+    entity VARCHAR(150) NOT NULL DEFAULT '',
+    property VARCHAR(150) NOT NULL DEFAULT '',
+    hour TIMESTAMP NOT NULL,
+    hits BIGINT DEFAULT NULL,
+    updated_time BIGINT NULL DEFAULT NULL,
+    UNIQUE (client_id, entity, property, hour)
+);
+
+CREATE INDEX IF NOT EXISTS idx_schema_hit_hourly_entity_property_hour
+    ON schema_hit_hourly(entity, property, hour);

--- a/migrations/20260310113000_add_schema_operation_hit_hourly.sql
+++ b/migrations/20260310113000_add_schema_operation_hit_hourly.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS schema_operation_hit_hourly (
+    id BIGSERIAL PRIMARY KEY,
+    client_id BIGINT NULL REFERENCES clients(id) ON DELETE CASCADE,
+    operation_name VARCHAR(255) NOT NULL DEFAULT '',
+    operation_type VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+    hour TIMESTAMP NOT NULL,
+    hits BIGINT DEFAULT NULL,
+    updated_time BIGINT NULL DEFAULT NULL,
+    UNIQUE (client_id, operation_name, operation_type, hour)
+);
+
+CREATE INDEX IF NOT EXISTS idx_schema_operation_hit_hourly_key
+    ON schema_operation_hit_hourly(operation_name, operation_type, hour);

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "ioredis": "5.0.2",
     "joi": "17.6.0",
     "knex": "2.4.2",
+    "lightweight-charts": "5.0.9",
+    "lightweight-charts-react-components": "1.4.0",
     "lodash": "4.17.21",
     "mysql2": "3.14.1",
     "pg": "8.16.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint": "oxlint client src",
     "lint:fix": "oxlint client src --fix",
     "lint:biome": "biome lint client src",
-    "lint:biome:fix": "biome lint --write client src"
+    "lint:biome:fix": "biome lint --write client src",
+    "lint:ci": "biome ci . && pnpm run lint"
   },
   "repository": {
     "type": "git",
@@ -51,7 +52,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "pnpm run format",
-      "pre-push": "pnpm run format"
+      "pre-push": "pnpm run lint:ci"
     }
   },
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       knex:
         specifier: 2.4.2
         version: 2.4.2(mysql2@3.14.1)(pg@8.16.3)
+      lightweight-charts:
+        specifier: 5.0.9
+        version: 5.0.9
+      lightweight-charts-react-components:
+        specifier: 1.4.0
+        version: 1.4.0(lightweight-charts@5.0.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -2720,6 +2726,9 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3444,6 +3453,16 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  lightweight-charts-react-components@1.4.0:
+    resolution: {integrity: sha512-FWzEiQDhQaQ04l6kV2fzsODK6jCrzbLOai+r6oEvCqC3tniXjKUAFHbTUlemII7PfiWYwyVAVgl1XRv72Q8Phw==}
+    peerDependencies:
+      lightweight-charts: '>=5 < 6'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  lightweight-charts@5.0.9:
+    resolution: {integrity: sha512-8oQIis8jfZVfSwz8j9Z5x3O79dIRTkEYI9UY7DKtE4O3ZxlHjMK3L0+4nOVOOFq4FHI/oSIzz1RHeNImCk6/Jg==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -7731,6 +7750,8 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -8722,6 +8743,16 @@ snapshots:
   lcov-parse@1.0.0: {}
 
   leven@3.1.0: {}
+
+  lightweight-charts-react-components@1.4.0(lightweight-charts@5.0.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      lightweight-charts: 5.0.9
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  lightweight-charts@5.0.9:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   lines-and-columns@1.2.4: {}
 

--- a/src/controller/schema.ts
+++ b/src/controller/schema.ts
@@ -15,7 +15,7 @@ export async function getAndValidateSchema(
 		? await schemaModel.getSchemaByServiceVersions({ trx, services })
 		: await schemaModel.getLastUpdatedForActiveServices({ trx });
 
-	logger.info('Validating schema. Got services schemas from DB transaction..', {
+	logger.info('Validating schema set loaded from transaction', {
 		schemas,
 	});
 
@@ -29,7 +29,7 @@ export async function getAndValidateSchema(
 export async function composeSupergraph(trx) {
 	const schemas = await schemaModel.getLastUpdatedForActiveServices({ trx });
 
-	logger.info('Composing graph. Got services schemas from DB transaction..', {
+	logger.info('Composing supergraph from active service schemas', {
 		schemas,
 	});
 
@@ -44,7 +44,7 @@ export async function pushAndValidateSchema({ service }) {
 	return await transact(async (trx) => {
 		const schema = await schemaModel.registerSchema({ trx, service });
 
-		logger.info('Registered service new schema in DB transaction..', {
+		logger.info('Registered new service schema in transaction', {
 			schema,
 		});
 

--- a/src/database/operation_hits.ts
+++ b/src/database/operation_hits.ts
@@ -1,0 +1,263 @@
+import { find } from 'lodash';
+
+import clientsModel from './clients';
+import { connection, transact } from './index';
+import { rowsFromRaw } from './raw-results';
+import redis from '../redis';
+import { logger } from '../logger';
+
+const operationHitModel = {
+	timer: null,
+	internalCache: [],
+	SAVE_INTERVAL_MS: 30 * 1000,
+	DELETE_INTERVAL_MS: 5 * 60 * 1000,
+	MAX_RETENTION_DAYS: 5,
+
+	init: function () {
+		logger.info('starting operation hit memory-to-db synchronizer');
+		operationHitModel.timer = setInterval(
+			operationHitModel.syncUniqueClientsToDb,
+			operationHitModel.SAVE_INTERVAL_MS
+		);
+
+		logger.info('starting operation hit periodic cleanup from db');
+		setInterval(async () => {
+			const now = Date.now();
+			await operationHitModel.deleteOlderThan(
+				now - operationHitModel.MAX_RETENTION_DAYS * 24 * 3600 * 1000
+			);
+		}, operationHitModel.DELETE_INTERVAL_MS);
+	},
+
+	syncUniqueClientsToDb: async function () {
+		for (const row of operationHitModel.internalCache) {
+			await operationHitModel.storeInDb(row);
+		}
+
+		operationHitModel.internalCache = [];
+	},
+
+	add: async function ({
+		name = null,
+		version = null,
+		operationName = 'anonymous',
+		operationType = 'UNKNOWN',
+		hour,
+	}: {
+		name: string | null;
+		version: string | null;
+		operationName: string;
+		operationType: string;
+		hour: string;
+	}) {
+		const row = find(operationHitModel.internalCache, {
+			name,
+			version,
+			operationName,
+			operationType,
+			hour,
+		});
+
+		if (row) {
+			row.hits++;
+		} else {
+			operationHitModel.internalCache.push({
+				name,
+				version,
+				operationName,
+				operationType,
+				hour,
+				hits: 1,
+			});
+		}
+	},
+
+	upsertOperationHit: async function ({
+		operationName,
+		operationType,
+		hour,
+		clientId = null,
+		incrementHits,
+		hits,
+	}) {
+		await transact(async (trx) => {
+			const operationHitCount = (
+				await trx('schema_operation_hit_hourly')
+					.count('operation_name', { as: 'cnt' })
+					.where({
+						operation_name: operationName,
+						operation_type: operationType,
+						hour,
+					})
+					.modify((queryBuilder) => {
+						if (clientId === null) {
+							queryBuilder.whereNull('client_id');
+							return;
+						}
+
+						queryBuilder.where({ client_id: clientId });
+					})
+			)[0].cnt;
+
+			if (operationHitCount > 0) {
+				await trx('schema_operation_hit_hourly')
+					.where({
+						operation_name: operationName,
+						operation_type: operationType,
+						hour,
+					})
+					.modify((queryBuilder) => {
+						if (clientId === null) {
+							queryBuilder.whereNull('client_id');
+							return;
+						}
+
+						queryBuilder.where({ client_id: clientId });
+					})
+					.update({
+						hits: incrementHits ? trx.raw('hits + ?', [hits]) : hits,
+						updated_time: Date.now(),
+					});
+			} else {
+				await trx('schema_operation_hit_hourly')
+					.insert({
+						operation_name: operationName,
+						operation_type: operationType,
+						hour,
+						hits,
+						client_id: clientId,
+						updated_time: Date.now(),
+					})
+					.onConflict(['client_id', 'operation_name', 'operation_type', 'hour'])
+					.ignore();
+			}
+		});
+	},
+
+	storeInDb: async function ({
+		incrementHits = true,
+		name = null,
+		version = null,
+		operationName,
+		operationType,
+		hour,
+		hits,
+	}) {
+		let client;
+
+		await transact(async (trx) => {
+			client = await connection('clients').where({ name, version }).first('id');
+
+			if (name && version && !client) {
+				client = {
+					id: await clientsModel.addClientVersion({
+						trx,
+						name,
+						version,
+					}),
+				};
+			}
+		});
+
+		await this.upsertOperationHit({
+			operationName,
+			operationType,
+			hour,
+			clientId: client ? client.id : null,
+			incrementHits,
+			hits,
+		});
+
+		return true;
+	},
+
+	getHits: async function ({
+		granularity = 'HOUR',
+		hours = 24,
+	}: {
+		granularity?: 'DAY' | 'HOUR';
+		hours?: number;
+	}) {
+		const sanitizedHours = Number.isFinite(hours)
+			? Math.max(1, Math.min(24 * 30, Math.floor(hours)))
+			: 24;
+
+		const cacheKey = `operation_hits.${granularity}.${sanitizedHours}`;
+		const cachedResults = await redis.get(cacheKey);
+
+		if (cachedResults) {
+			return JSON.parse(cachedResults);
+		}
+
+		const results =
+			granularity === 'HOUR'
+				? await connection.raw(
+						`SELECT operation_name as "operationName",
+								operation_type as "operationType",
+								TO_CHAR(hour, 'YYYY-MM-DD"T"HH24:00:00"Z"') as bucket,
+								SUM(hits)::int as hits
+						 FROM schema_operation_hit_hourly
+						 WHERE hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY operation_name, operation_type, hour
+						 ORDER BY hour, operation_name`,
+						[sanitizedHours]
+				  )
+				: await connection.raw(
+						`SELECT operation_name as "operationName",
+								operation_type as "operationType",
+								TO_CHAR(DATE_TRUNC('day', hour), 'YYYY-MM-DD') as bucket,
+								SUM(hits)::int as hits
+						 FROM schema_operation_hit_hourly
+						 WHERE hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY operation_name, operation_type, DATE_TRUNC('day', hour)
+						 ORDER BY DATE_TRUNC('day', hour), operation_name`,
+						[sanitizedHours]
+				  );
+
+		const rows = rowsFromRaw(results);
+		await redis.set(cacheKey, JSON.stringify(rows), 60);
+		return rows;
+	},
+
+	getTopOperations: async function ({ hours = 24, limit = 20 }) {
+		const sanitizedHours = Number.isFinite(hours)
+			? Math.max(1, Math.min(24 * 30, Math.floor(hours)))
+			: 24;
+		const sanitizedLimit = Number.isFinite(limit)
+			? Math.max(1, Math.min(200, Math.floor(limit)))
+			: 20;
+
+		const cacheKey = `operation_hits.top.${sanitizedHours}.${sanitizedLimit}`;
+		const cachedResults = await redis.get(cacheKey);
+
+		if (cachedResults) {
+			return JSON.parse(cachedResults);
+		}
+
+		const results = await connection.raw(
+			`SELECT operation_name as "operationName",
+					operation_type as "operationType",
+					SUM(hits)::int as hits
+			 FROM schema_operation_hit_hourly
+			 WHERE hour >= NOW() - (? || ' hour')::interval
+			 GROUP BY operation_name, operation_type
+			 ORDER BY hits DESC, operation_name
+			 LIMIT ?`,
+			[sanitizedHours, sanitizedLimit]
+		);
+
+		const rows = rowsFromRaw(results);
+		await redis.set(cacheKey, JSON.stringify(rows), 60);
+		return rows;
+	},
+
+	deleteOlderThan: async function (timestampMs) {
+		const hourFormatted = new Date(timestampMs).toISOString();
+		await connection.raw(
+			`DELETE FROM schema_operation_hit_hourly WHERE hour < ?`,
+			[hourFormatted]
+		);
+	},
+};
+
+export default operationHitModel;

--- a/src/database/operation_hits.ts
+++ b/src/database/operation_hits.ts
@@ -201,7 +201,7 @@ const operationHitModel = {
 						 GROUP BY operation_name, operation_type, hour
 						 ORDER BY hour, operation_name`,
 						[sanitizedHours]
-				  )
+					)
 				: await connection.raw(
 						`SELECT operation_name as "operationName",
 								operation_type as "operationType",
@@ -212,7 +212,7 @@ const operationHitModel = {
 						 GROUP BY operation_name, operation_type, DATE_TRUNC('day', hour)
 						 ORDER BY DATE_TRUNC('day', hour), operation_name`,
 						[sanitizedHours]
-				  );
+					);
 
 		const rows = rowsFromRaw(results);
 		await redis.set(cacheKey, JSON.stringify(rows), 60);

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -492,7 +492,8 @@ const schemaModel = {
 
 		entries.sort((left, right) => {
 			const timeDiff =
-				new Date(right.addedTime).getTime() - new Date(left.addedTime).getTime();
+				new Date(right.addedTime).getTime() -
+				new Date(left.addedTime).getTime();
 
 			if (timeDiff !== 0) {
 				return timeDiff;

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -7,6 +7,7 @@ import { connection } from './index';
 import { firstInsertId, rowsFromRaw } from './raw-results';
 import servicesModel from './services';
 import { PublicError } from '../helpers/error';
+import { diffSchemaTypeDefs } from '../helpers/schema-change-log';
 import { logger } from '../logger';
 
 function isDevVersion(version: string) {
@@ -17,6 +18,15 @@ interface SchemaRecord {
 	id: string;
 	type_defs: string;
 	is_active: boolean | number;
+}
+
+interface SchemaHistoryRow {
+	id: number;
+	uuid: string | null;
+	type_defs: string;
+	added_time: string;
+	service_name: string;
+	service_id: number;
 }
 
 function normalizeSchemaRow<T extends Record<string, any>>(row: T): T {
@@ -420,6 +430,78 @@ const schemaModel = {
 		}
 
 		return schema;
+	},
+
+	getSchemaChangeLog: async function ({
+		trx,
+		limit = 200,
+		offset = 0,
+		serviceName,
+	}: {
+		trx: Knex<SchemaRecord>;
+		limit?: number;
+		offset?: number;
+		serviceName?: string;
+	}) {
+		const historyQuery = trx('schema')
+			.select(
+				'schema.id',
+				'schema.uuid',
+				'schema.type_defs',
+				'schema.added_time',
+				'schema.service_id',
+				'services.name as service_name'
+			)
+			.innerJoin('services', 'services.id', 'schema.service_id')
+			.orderBy('schema.added_time', 'asc')
+			.orderBy('schema.id', 'asc');
+
+		if (serviceName) {
+			historyQuery.where('services.name', serviceName);
+		}
+
+		const historyRows = (await historyQuery) as SchemaHistoryRow[];
+		const previousTypeDefsByService = new Map<string, string | null>();
+		const entries: Array<{
+			serviceName: string;
+			schemaId: number;
+			schemaUUID: string | null;
+			addedTime: string;
+			changeType: string;
+			change: string;
+		}> = [];
+
+		for (const row of historyRows) {
+			const previousTypeDefs =
+				previousTypeDefsByService.get(row.service_name) || null;
+			const changes = diffSchemaTypeDefs(previousTypeDefs, row.type_defs);
+
+			for (const entry of changes) {
+				entries.push({
+					serviceName: row.service_name,
+					schemaId: row.id,
+					schemaUUID: row.uuid || null,
+					addedTime: row.added_time,
+					changeType: entry.changeType,
+					change: entry.change,
+				});
+			}
+
+			previousTypeDefsByService.set(row.service_name, row.type_defs);
+		}
+
+		entries.sort((left, right) => {
+			const timeDiff =
+				new Date(right.addedTime).getTime() - new Date(left.addedTime).getTime();
+
+			if (timeDiff !== 0) {
+				return timeDiff;
+			}
+
+			return right.schemaId - left.schemaId;
+		});
+
+		return entries.slice(offset, offset + limit);
 	},
 
 	listMigrateableSchemas: async function (knex, limit = 100) {

--- a/src/database/schema_hits.ts
+++ b/src/database/schema_hits.ts
@@ -61,12 +61,14 @@ const schemaHitModel = {
 		entity,
 		property,
 		day,
+		hour = null,
 	}: {
 		name: string | null;
 		version: string | null;
 		entity: string;
 		property: string;
 		day: string;
+		hour?: string | null;
 	}) {
 		const row = find(schemaHitModel.internalCache, {
 			name,
@@ -74,6 +76,7 @@ const schemaHitModel = {
 			entity,
 			property,
 			day,
+			hour,
 		});
 
 		if (row) {
@@ -85,53 +88,106 @@ const schemaHitModel = {
 				entity,
 				property,
 				day,
+				hour,
 				hits: 1,
 			});
 		}
+	},
+
+	upsertSchemaHit: async function ({
+		table,
+		bucketColumn,
+		bucketValue,
+		entity,
+		property,
+		clientId = null,
+		incrementHits,
+		hits,
+	}) {
+		await transact(async (trx) => {
+			const clientHitCount = (
+				await trx(table).count('entity', { as: 'cnt' }).where({
+					entity,
+					property,
+					[bucketColumn]: bucketValue,
+				})
+					.modify((queryBuilder) => {
+						if (clientId === null) {
+							queryBuilder.whereNull('client_id');
+							return;
+						}
+
+						queryBuilder.where({ client_id: clientId });
+					})
+			)[0].cnt;
+
+			if (clientHitCount > 0) {
+				await trx(table)
+					.where({
+						entity,
+						property,
+						[bucketColumn]: bucketValue,
+					})
+					.modify((queryBuilder) => {
+						if (clientId === null) {
+							queryBuilder.whereNull('client_id');
+							return;
+						}
+
+						queryBuilder.where({ client_id: clientId });
+					})
+					.update({
+						hits: incrementHits ? trx.raw('hits + ?', [hits]) : hits,
+						updated_time: Date.now(),
+					});
+			} else {
+				await trx(table)
+					.insert({
+						entity,
+						property,
+						[bucketColumn]: bucketValue,
+						hits,
+						client_id: clientId,
+						updated_time: Date.now(),
+					})
+					.onConflict(['client_id', 'entity', 'property', bucketColumn])
+					.ignore();
+			}
+		});
 	},
 
 	addSchemaHitForNewClient: async function ({
 		entity,
 		property,
 		day,
+		hour,
 		incrementHits,
 		hits,
 	}) {
-		await transact(async (trx) => {
-			const clientHitCount = (
-				await trx('schema_hit').count('entity', { as: 'cnt' }).where({
-					entity,
-					property,
-					day,
-					client_id: null,
-				})
-			)[0].cnt;
+		await this.upsertSchemaHit({
+			table: 'schema_hit',
+			bucketColumn: 'day',
+			bucketValue: day,
+			entity,
+			property,
+			clientId: null,
+			incrementHits,
+			hits,
+		});
 
-			if (clientHitCount > 0) {
-				await trx('schema_hit')
-					.where({
-						entity,
-						property,
-						day,
-					})
-					.whereNull('client_id')
-					.update({
-						hits: incrementHits ? trx.raw('hits + ?', [hits]) : hits,
-						updated_time: Date.now(),
-					});
-			} else {
-				await trx('schema_hit')
-					.insert({
-						entity,
-						property,
-						day,
-						hits,
-						client_id: null,
-						updated_time: Date.now(),
-					})
-					.onConflict(['client_id', 'entity', 'property', 'day'])
-					.ignore();
-			}
+		if (!hour) {
+			return;
+		}
+
+		await this.upsertSchemaHit({
+			table: 'schema_hit_hourly',
+			bucketColumn: 'hour',
+			bucketValue: hour,
+			entity,
+			property,
+			clientId: null,
+			incrementHits,
+			hits,
 		});
 	},
 
@@ -139,45 +195,35 @@ const schemaHitModel = {
 		entity,
 		property,
 		day,
+		hour,
 		client,
 		incrementHits,
 		hits,
 	}) {
-		await transact(async (trx) => {
-			const clientHitCount = (
-				await trx('schema_hit').count('entity', { as: 'cnt' }).where({
-					entity,
-					property,
-					day,
-					client_id: client.id,
-				})
-			)[0].cnt;
+		await this.upsertSchemaHit({
+			table: 'schema_hit',
+			bucketColumn: 'day',
+			bucketValue: day,
+			entity,
+			property,
+			clientId: client.id,
+			incrementHits,
+			hits,
+		});
 
-			if (clientHitCount > 0) {
-				await trx('schema_hit')
-					.where({
-						entity,
-						property,
-						day,
-						client_id: client.id,
-					})
-					.update({
-						hits: incrementHits ? trx.raw('hits + ?', [hits]) : hits,
-						updated_time: Date.now(),
-					});
-			} else {
-				await trx('schema_hit')
-					.insert({
-						entity,
-						property,
-						day,
-						hits,
-						client_id: client.id,
-						updated_time: Date.now(),
-					})
-					.onConflict(['client_id', 'entity', 'property', 'day'])
-					.ignore();
-			}
+		if (!hour) {
+			return;
+		}
+
+		await this.upsertSchemaHit({
+			table: 'schema_hit_hourly',
+			bucketColumn: 'hour',
+			bucketValue: hour,
+			entity,
+			property,
+			clientId: client.id,
+			incrementHits,
+			hits,
 		});
 	},
 	storeInDb: async function ({
@@ -187,6 +233,7 @@ const schemaHitModel = {
 		entity,
 		property,
 		day,
+		hour = null,
 		hits,
 	}) {
 		let client;
@@ -222,6 +269,7 @@ const schemaHitModel = {
 				entity,
 				property,
 				day,
+				hour,
 				client,
 				incrementHits,
 				hits,
@@ -231,6 +279,7 @@ const schemaHitModel = {
 				entity,
 				property,
 				day,
+				hour,
 				incrementHits,
 				hits,
 			});
@@ -239,31 +288,52 @@ const schemaHitModel = {
 		return true;
 	},
 
-	get: async function ({ entity, property }) {
-		const cachedResults = await redis.get(`schema_hits.${entity}.${property}`);
+	get: async function ({ entity, property, granularity = 'DAY' }) {
+		const cachedResults = await redis.get(
+			`schema_hits.${granularity}.${entity}.${property}`
+		);
 
 		if (cachedResults) {
 			return JSON.parse(cachedResults);
 		}
 
-		const results = await connection.raw(
-			`SELECT TO_CHAR(sh.day, 'YYYY-MM-DD') as day,
-					SUM(sh.hits)                    as hits,
-					sh.entity,
-					sh.property,
-					c.name                          as "clientName"
-			 FROM schema_hit sh
-					  LEFT JOIN clients c on sh.client_id = c.id
-			 WHERE sh.entity = ?
-			   AND sh.property = ?
-			 GROUP BY c.name, day, sh.entity, sh.property
-			 ORDER BY c.name, day`,
-			[entity, property]
-		);
+		const results =
+			granularity === 'HOUR'
+				? await connection.raw(
+						`SELECT TO_CHAR(sh.hour, 'YYYY-MM-DD') as day,
+								TO_CHAR(sh.hour, 'YYYY-MM-DD"T"HH24:00:00"Z"') as bucket,
+								SUM(sh.hits)                                    as hits,
+								sh.entity,
+								sh.property,
+								c.name                                           as "clientName"
+						 FROM schema_hit_hourly sh
+								  LEFT JOIN clients c on sh.client_id = c.id
+						 WHERE sh.entity = ?
+						   AND sh.property = ?
+						 GROUP BY c.name, sh.hour, sh.entity, sh.property
+						 ORDER BY c.name, sh.hour`,
+						[entity, property]
+				  )
+				: await connection.raw(
+						`SELECT TO_CHAR(sh.day, 'YYYY-MM-DD') as day,
+								TO_CHAR(sh.day, 'YYYY-MM-DD') as bucket,
+								SUM(sh.hits)                    as hits,
+								sh.entity,
+								sh.property,
+								c.name                          as "clientName"
+						 FROM schema_hit sh
+								  LEFT JOIN clients c on sh.client_id = c.id
+						 WHERE sh.entity = ?
+						   AND sh.property = ?
+						 GROUP BY c.name, day, sh.entity, sh.property
+						 ORDER BY c.name, day`,
+						[entity, property]
+				  );
+
 		const rows = rowsFromRaw(results);
 
 		await redis.set(
-			`schema_hits.${entity}.${property}`,
+			`schema_hits.${granularity}.${entity}.${property}`,
 			JSON.stringify(rows),
 			60
 		);
@@ -271,14 +341,89 @@ const schemaHitModel = {
 		return rows;
 	},
 
+	getEntityHits: async function ({
+		granularity = 'HOUR',
+		hours = 24,
+	}: {
+		granularity?: 'DAY' | 'HOUR';
+		hours?: number;
+	}) {
+		const sanitizedHours = Number.isFinite(hours)
+			? Math.max(1, Math.min(24 * 30, Math.floor(hours)))
+			: 24;
+
+		const cacheKey = `schema_hits_entity.${granularity}.${sanitizedHours}`;
+		const cachedResults = await redis.get(cacheKey);
+
+		if (cachedResults) {
+			return JSON.parse(cachedResults);
+		}
+
+		const results =
+			granularity === 'HOUR'
+				? await connection.raw(
+						`SELECT sh.entity,
+								TO_CHAR(sh.hour, 'YYYY-MM-DD"T"HH24:00:00"Z"') as bucket,
+								SUM(sh.hits)::int as hits
+						 FROM schema_hit_hourly sh
+						 WHERE sh.hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY sh.entity, sh.hour
+						 ORDER BY sh.hour, sh.entity`,
+						[sanitizedHours]
+				  )
+				: await connection.raw(
+						`SELECT sh.entity,
+								TO_CHAR(sh.day, 'YYYY-MM-DD') as bucket,
+								SUM(sh.hits)::int as hits
+						 FROM schema_hit sh
+						 WHERE sh.day >= CURRENT_DATE - (? || ' day')::interval
+						 GROUP BY sh.entity, sh.day
+						 ORDER BY sh.day, sh.entity`,
+						[Math.max(1, Math.ceil(sanitizedHours / 24))]
+				  );
+
+		const rows = rowsFromRaw(results);
+
+		await redis.set(cacheKey, JSON.stringify(rows), 60);
+
+		return rows;
+	},
+
 	listFields: async function () {
 		const results = await connection.raw(
-			`SELECT sh.entity,
-					sh.property,
-					SUM(sh.hits)::int as "hitsSum"
-			 FROM schema_hit sh
-			 GROUP BY sh.entity, sh.property
-			 ORDER BY "hitsSum" DESC, sh.entity, sh.property`
+			`SELECT daily.entity,
+					daily.property,
+					daily."hitsSum",
+					COALESCE(hourly_1h."hits1h", 0)::int as "hits1h",
+					COALESCE(hourly_24h."hits24h", 0)::int as "hits24h"
+			 FROM (
+					  SELECT sh.entity,
+							 sh.property,
+							 SUM(sh.hits)::int as "hitsSum"
+					  FROM schema_hit sh
+					  GROUP BY sh.entity, sh.property
+				  ) daily
+					  LEFT JOIN (
+				 SELECT sh.entity,
+						sh.property,
+						SUM(sh.hits)::int as "hits1h"
+				 FROM schema_hit_hourly sh
+				 WHERE sh.hour >= NOW() - INTERVAL '1 hour'
+				 GROUP BY sh.entity, sh.property
+			 ) hourly_1h
+								ON daily.entity = hourly_1h.entity
+									AND daily.property = hourly_1h.property
+					  LEFT JOIN (
+				 SELECT sh.entity,
+						sh.property,
+						SUM(sh.hits)::int as "hits24h"
+				 FROM schema_hit_hourly sh
+				 WHERE sh.hour >= NOW() - INTERVAL '24 hour'
+				 GROUP BY sh.entity, sh.property
+			 ) hourly_24h
+								ON daily.entity = hourly_24h.entity
+									AND daily.property = hourly_24h.property
+			 ORDER BY "hits24h" DESC, "hitsSum" DESC, daily.entity, daily.property`
 		);
 
 		return rowsFromRaw(results);
@@ -317,6 +462,7 @@ const schemaHitModel = {
 
 	deleteOlderThan: async function (timestampMs) {
 		const dayFormatted = new Date(timestampMs).toISOString().slice(0, 10);
+		const hourFormatted = new Date(timestampMs).toISOString();
 
 		logger.info(`Cleaning up schema usage older than ${dayFormatted}`);
 
@@ -325,6 +471,12 @@ const schemaHitModel = {
 			 FROM schema_hit
 			 WHERE day < ?`,
 			[dayFormatted]
+		);
+		await connection.raw(
+			`DELETE
+			 FROM schema_hit_hourly
+			 WHERE hour < ?`,
+			[hourFormatted]
 		);
 
 		// prometheus.logHitsCleanup(dayFormatted);

--- a/src/database/schema_hits.ts
+++ b/src/database/schema_hits.ts
@@ -389,6 +389,56 @@ const schemaHitModel = {
 		return rows;
 	},
 
+	getClientHits: async function ({
+		granularity = 'HOUR',
+		hours = 24,
+	}: {
+		granularity?: 'DAY' | 'HOUR';
+		hours?: number;
+	}) {
+		const sanitizedHours = Number.isFinite(hours)
+			? Math.max(1, Math.min(24 * 30, Math.floor(hours)))
+			: 24;
+
+		const cacheKey = `schema_hits_client.${granularity}.${sanitizedHours}`;
+		const cachedResults = await redis.get(cacheKey);
+
+		if (cachedResults) {
+			return JSON.parse(cachedResults);
+		}
+
+		const results =
+			granularity === 'HOUR'
+				? await connection.raw(
+						`SELECT c.name as "clientName",
+								c.version as "clientVersion",
+								TO_CHAR(sh.hour, 'YYYY-MM-DD"T"HH24:00:00"Z"') as bucket,
+								SUM(sh.hits)::int as hits
+						 FROM schema_hit_hourly sh
+								  LEFT JOIN clients c on sh.client_id = c.id
+						 WHERE sh.hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY c.name, c.version, sh.hour
+						 ORDER BY sh.hour, c.name, c.version`,
+						[sanitizedHours]
+				  )
+				: await connection.raw(
+						`SELECT c.name as "clientName",
+								c.version as "clientVersion",
+								TO_CHAR(DATE_TRUNC('day', sh.hour), 'YYYY-MM-DD') as bucket,
+								SUM(sh.hits)::int as hits
+						 FROM schema_hit_hourly sh
+								  LEFT JOIN clients c on sh.client_id = c.id
+						 WHERE sh.hour >= NOW() - (? || ' hour')::interval
+						 GROUP BY c.name, c.version, DATE_TRUNC('day', sh.hour)
+						 ORDER BY DATE_TRUNC('day', sh.hour), c.name, c.version`,
+						[sanitizedHours]
+				  );
+
+		const rows = rowsFromRaw(results);
+		await redis.set(cacheKey, JSON.stringify(rows), 60);
+		return rows;
+	},
+
 	listFields: async function () {
 		const results = await connection.raw(
 			`SELECT daily.entity,

--- a/src/database/schema_hits.ts
+++ b/src/database/schema_hits.ts
@@ -106,11 +106,13 @@ const schemaHitModel = {
 	}) {
 		await transact(async (trx) => {
 			const clientHitCount = (
-				await trx(table).count('entity', { as: 'cnt' }).where({
-					entity,
-					property,
-					[bucketColumn]: bucketValue,
-				})
+				await trx(table)
+					.count('entity', { as: 'cnt' })
+					.where({
+						entity,
+						property,
+						[bucketColumn]: bucketValue,
+					})
 					.modify((queryBuilder) => {
 						if (clientId === null) {
 							queryBuilder.whereNull('client_id');
@@ -313,7 +315,7 @@ const schemaHitModel = {
 						 GROUP BY c.name, sh.hour, sh.entity, sh.property
 						 ORDER BY c.name, sh.hour`,
 						[entity, property]
-				  )
+					)
 				: await connection.raw(
 						`SELECT TO_CHAR(sh.day, 'YYYY-MM-DD') as day,
 								TO_CHAR(sh.day, 'YYYY-MM-DD') as bucket,
@@ -328,7 +330,7 @@ const schemaHitModel = {
 						 GROUP BY c.name, day, sh.entity, sh.property
 						 ORDER BY c.name, day`,
 						[entity, property]
-				  );
+					);
 
 		const rows = rowsFromRaw(results);
 
@@ -370,7 +372,7 @@ const schemaHitModel = {
 						 GROUP BY sh.entity, sh.hour
 						 ORDER BY sh.hour, sh.entity`,
 						[sanitizedHours]
-				  )
+					)
 				: await connection.raw(
 						`SELECT sh.entity,
 								TO_CHAR(sh.day, 'YYYY-MM-DD') as bucket,
@@ -380,7 +382,7 @@ const schemaHitModel = {
 						 GROUP BY sh.entity, sh.day
 						 ORDER BY sh.day, sh.entity`,
 						[Math.max(1, Math.ceil(sanitizedHours / 24))]
-				  );
+					);
 
 		const rows = rowsFromRaw(results);
 
@@ -420,7 +422,7 @@ const schemaHitModel = {
 						 GROUP BY c.name, c.version, sh.hour
 						 ORDER BY sh.hour, c.name, c.version`,
 						[sanitizedHours]
-				  )
+					)
 				: await connection.raw(
 						`SELECT c.name as "clientName",
 								c.version as "clientVersion",
@@ -432,7 +434,7 @@ const schemaHitModel = {
 						 GROUP BY c.name, c.version, DATE_TRUNC('day', sh.hour)
 						 ORDER BY DATE_TRUNC('day', sh.hour), c.name, c.version`,
 						[sanitizedHours]
-				  );
+					);
 
 		const rows = rowsFromRaw(results);
 		await redis.set(cacheKey, JSON.stringify(rows), 60);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -63,6 +63,8 @@ export default {
 			}),
 		schemaEntityHits: async (_, { granularity, hours }) =>
 			await schemaHit.getEntityHits({ granularity, hours }),
+		schemaClientHits: async (_, { granularity, hours }) =>
+			await schemaHit.getClientHits({ granularity, hours }),
 		schemaOperationHits: async (_, { granularity, hours }) =>
 			await operationHit.getHits({ granularity, hours }),
 		schemaTopOperations: async (_, { hours, limit }) =>

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -15,9 +15,11 @@ import containersModel from '../database/containers';
 import servicesModel from '../database/services';
 
 import schemaHit from '../database/schema_hits';
+import operationHit from '../database/operation_hits';
 import clientsModel from '../database/clients';
 
 import PersistedQueriesModel from '../database/persisted_queries';
+import { getServiceHealthStatus } from './service-health';
 
 const dateTime = new Intl.DateTimeFormat('en-GB', {
 	weekday: 'long',
@@ -49,9 +51,22 @@ export default {
 
 			return schema;
 		},
-		schemaPropertyHitsByClient: async (_, { entity, property }) =>
-			await schemaHit.get({ entity, property }),
+		schemaPropertyHitsByClient: async (_, { entity, property, granularity }) =>
+			await schemaHit.get({ entity, property, granularity }),
 		schemaFieldsUsage: async () => await schemaHit.listFields(),
+		schemaChangeLog: async (_, { limit, offset, serviceName }) =>
+			await schemaModel.getSchemaChangeLog({
+				trx: connection,
+				limit,
+				offset,
+				serviceName,
+			}),
+		schemaEntityHits: async (_, { granularity, hours }) =>
+			await schemaHit.getEntityHits({ granularity, hours }),
+		schemaOperationHits: async (_, { granularity, hours }) =>
+			await operationHit.getHits({ granularity, hours }),
+		schemaTopOperations: async (_, { hours, limit }) =>
+			await operationHit.getTopOperations({ hours, limit }),
 
 		persistedQueries: async (
 			parent,
@@ -156,6 +171,7 @@ export default {
 
 			return schemas;
 		},
+		healthStatus: async (parent) => getServiceHealthStatus(parent.url),
 	},
 	SchemaDefinition: {
 		service: (parent, args, { dataloaders }) =>

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -28,6 +28,10 @@ export default gql`
 			granularity: UsageGranularity = HOUR
 			hours: Int = 24
 		): [SchemaEntityHit]
+		schemaClientHits(
+			granularity: UsageGranularity = HOUR
+			hours: Int = 24
+		): [SchemaClientHit]
 		schemaOperationHits(
 			granularity: UsageGranularity = HOUR
 			hours: Int = 24
@@ -130,6 +134,13 @@ export default gql`
 
 	type SchemaEntityHit {
 		entity: String!
+		bucket: String!
+		hits: Int!
+	}
+
+	type SchemaClientHit {
+		clientName: String
+		clientVersion: String
 		bucket: String!
 		hits: Int!
 	}

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -16,8 +16,23 @@ export default gql`
 		schemaPropertyHitsByClient(
 			entity: String!
 			property: String!
+			granularity: UsageGranularity = DAY
 		): [SchemaHitByClient]
 		schemaFieldsUsage: [SchemaField]
+		schemaChangeLog(
+			limit: Int = 200
+			offset: Int = 0
+			serviceName: String
+		): [SchemaChangeLogEntry!]!
+		schemaEntityHits(
+			granularity: UsageGranularity = HOUR
+			hours: Int = 24
+		): [SchemaEntityHit]
+		schemaOperationHits(
+			granularity: UsageGranularity = HOUR
+			hours: Int = 24
+		): [SchemaOperationHit]
+		schemaTopOperations(hours: Int = 24, limit: Int = 20): [SchemaOperationSummary]
 
 		persistedQueries(
 			searchFragment: String
@@ -31,6 +46,11 @@ export default gql`
 		clientVersions(since: DateTime): [ClientVersion]
 		logs: JSON
 		search(filter: String!): [SearchResult]
+	}
+
+	enum UsageGranularity {
+		DAY
+		HOUR
 	}
 
 	union SearchResult = Service | SchemaDefinition
@@ -47,6 +67,7 @@ export default gql`
 		hits: Int!
 
 		day: Date!
+		bucket: String!
 		clientName: String
 	}
 	type SchemaHitByClientVersion {
@@ -94,6 +115,36 @@ export default gql`
 		property: String!
 		clientVersionId: Int
 		hitsSum: Int
+		hits1h: Int
+		hits24h: Int
+	}
+
+	type SchemaChangeLogEntry {
+		serviceName: String!
+		schemaId: Int!
+		schemaUUID: String
+		addedTime: DateTime!
+		changeType: String!
+		change: String!
+	}
+
+	type SchemaEntityHit {
+		entity: String!
+		bucket: String!
+		hits: Int!
+	}
+
+	type SchemaOperationHit {
+		operationName: String!
+		operationType: String!
+		bucket: String!
+		hits: Int!
+	}
+
+	type SchemaOperationSummary {
+		operationName: String!
+		operationType: String!
+		hits: Int!
 	}
 
 	type Container {
@@ -107,8 +158,14 @@ export default gql`
 		id: Int!
 		name: String!
 		url: String
+		healthStatus: ServiceHealthStatus!
 
 		schemas(limit: Int, offset: Int, filter: String): [SchemaDefinition!]!
+	}
+
+	enum ServiceHealthStatus {
+		UP
+		DOWN
 	}
 
 	type PersistedQuery {

--- a/src/graphql/service-health.ts
+++ b/src/graphql/service-health.ts
@@ -1,0 +1,107 @@
+const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_CACHE_TTL_MS = 30000;
+
+type ServiceHealthStatus = 'UP' | 'DOWN';
+
+type CacheEntry = {
+	status: ServiceHealthStatus;
+	expiresAt: number;
+};
+
+const healthCache = new Map<string, CacheEntry>();
+const inFlightChecks = new Map<string, Promise<ServiceHealthStatus>>();
+
+function getProbeTimeoutMs() {
+	const value = Number(process.env.SERVICE_HEALTH_TIMEOUT_MS);
+	return Number.isFinite(value) && value > 0 ? value : DEFAULT_TIMEOUT_MS;
+}
+
+function getCacheTtlMs() {
+	const value = Number(process.env.SERVICE_HEALTH_CACHE_TTL_MS);
+	return Number.isFinite(value) && value > 0 ? value : DEFAULT_CACHE_TTL_MS;
+}
+
+async function probeService(url: string): Promise<ServiceHealthStatus> {
+	if (!url) {
+		return 'DOWN';
+	}
+
+	const normalizedUrl = normalizeServiceUrl(url);
+	if (!normalizedUrl) {
+		return 'DOWN';
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), getProbeTimeoutMs());
+
+	try {
+		const response = await fetch(normalizedUrl, {
+			method: 'POST',
+			signal: controller.signal,
+			redirect: 'follow',
+			headers: {
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({
+				query: 'query ServiceHealthCheck { __typename }',
+				operationName: 'ServiceHealthCheck',
+			}),
+		});
+
+		// If we got an HTTP response at all (including auth or validation errors),
+		// the service is reachable. Only transport failures/timeouts are DOWN.
+		if (response.status >= 100 && response.status < 500) {
+			return 'UP';
+		}
+
+		return response.status >= 500 ? 'DOWN' : 'UP';
+	} catch {
+		return 'DOWN';
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function normalizeServiceUrl(url: string): string | null {
+	try {
+		return new URL(url).toString();
+	} catch {
+		try {
+			return new URL(`http://${url}`).toString();
+		} catch {
+			return null;
+		}
+	}
+}
+
+export async function getServiceHealthStatus(
+	url: string
+): Promise<ServiceHealthStatus> {
+	const now = Date.now();
+	const cached = healthCache.get(url);
+
+	if (cached && cached.expiresAt > now) {
+		return cached.status;
+	}
+
+	const pending = inFlightChecks.get(url);
+	if (pending) {
+		return pending;
+	}
+
+	const probePromise = probeService(url)
+		.then((status) => {
+			healthCache.set(url, {
+				status,
+				expiresAt: Date.now() + getCacheTtlMs(),
+			});
+			return status;
+		})
+		.finally(() => {
+			inFlightChecks.delete(url);
+		});
+
+	inFlightChecks.set(url, probePromise);
+
+	return probePromise;
+}

--- a/src/helpers/schema-change-log.ts
+++ b/src/helpers/schema-change-log.ts
@@ -78,7 +78,10 @@ function addField(
 	typeEntry.fields.set(fieldNode.name.value, typeNodeToString(fieldNode.type));
 }
 
-function addFieldArguments(typeEntry: ParsedType, fieldNode: FieldDefinitionNode) {
+function addFieldArguments(
+	typeEntry: ParsedType,
+	fieldNode: FieldDefinitionNode
+) {
 	if (!fieldNode.arguments || !fieldNode.arguments.length) {
 		return;
 	}
@@ -105,7 +108,10 @@ function parseSchema(typeDefs: string): ParsedSchema {
 	return parsedSchema;
 }
 
-function consumeDefinition(parsedSchema: ParsedSchema, definition: DefinitionNode) {
+function consumeDefinition(
+	parsedSchema: ParsedSchema,
+	definition: DefinitionNode
+) {
 	switch (definition.kind) {
 		case 'ObjectTypeDefinition':
 		case 'ObjectTypeExtension': {
@@ -191,9 +197,13 @@ function compareFieldArguments(
 	afterArgs: Map<string, string> | undefined,
 	rows: SchemaDiffRow[]
 ) {
-	const beforeArgNames = new Set(beforeArgs ? Array.from(beforeArgs.keys()) : []);
+	const beforeArgNames = new Set(
+		beforeArgs ? Array.from(beforeArgs.keys()) : []
+	);
 	const afterArgNames = new Set(afterArgs ? Array.from(afterArgs.keys()) : []);
-	const argNames = Array.from(new Set([...beforeArgNames, ...afterArgNames])).sort();
+	const argNames = Array.from(
+		new Set([...beforeArgNames, ...afterArgNames])
+	).sort();
 
 	for (const argName of argNames) {
 		const hadArg = beforeArgs?.has(argName);
@@ -322,7 +332,9 @@ function compareUnionMembers(
 ) {
 	const beforeMembers = new Set(Array.from(beforeType.unionMembers));
 	const afterMembers = new Set(Array.from(afterType.unionMembers));
-	const members = Array.from(new Set([...beforeMembers, ...afterMembers])).sort();
+	const members = Array.from(
+		new Set([...beforeMembers, ...afterMembers])
+	).sort();
 
 	for (const member of members) {
 		const hadMember = beforeType.unionMembers.has(member);

--- a/src/helpers/schema-change-log.ts
+++ b/src/helpers/schema-change-log.ts
@@ -1,0 +1,433 @@
+import {
+	parse,
+	type DefinitionNode,
+	type FieldDefinitionNode,
+	type InputValueDefinitionNode,
+	type TypeNode,
+} from 'graphql';
+
+type DiffKind =
+	| 'INITIAL'
+	| 'TYPE_ADDED'
+	| 'TYPE_REMOVED'
+	| 'TYPE_KIND_CHANGED'
+	| 'FIELD_ADDED'
+	| 'FIELD_REMOVED'
+	| 'FIELD_TYPE_CHANGED'
+	| 'ARG_ADDED'
+	| 'ARG_REMOVED'
+	| 'ARG_TYPE_CHANGED'
+	| 'ENUM_VALUE_ADDED'
+	| 'ENUM_VALUE_REMOVED'
+	| 'UNION_MEMBER_ADDED'
+	| 'UNION_MEMBER_REMOVED'
+	| 'ERROR';
+
+interface SchemaDiffRow {
+	changeType: DiffKind;
+	change: string;
+}
+
+interface ParsedType {
+	kind: string;
+	fields: Map<string, string>;
+	argsByField: Map<string, Map<string, string>>;
+	enumValues: Set<string>;
+	unionMembers: Set<string>;
+}
+
+interface ParsedSchema {
+	types: Map<string, ParsedType>;
+}
+
+function typeNodeToString(typeNode: TypeNode): string {
+	switch (typeNode.kind) {
+		case 'NamedType':
+			return typeNode.name.value;
+		case 'ListType':
+			return `[${typeNodeToString(typeNode.type)}]`;
+		case 'NonNullType':
+			return `${typeNodeToString(typeNode.type)}!`;
+		default:
+			return '';
+	}
+}
+
+function ensureType(parsedSchema: ParsedSchema, name: string, kind: string) {
+	const existing = parsedSchema.types.get(name);
+
+	if (existing) {
+		return existing;
+	}
+
+	const created: ParsedType = {
+		kind,
+		fields: new Map(),
+		argsByField: new Map(),
+		enumValues: new Set(),
+		unionMembers: new Set(),
+	};
+	parsedSchema.types.set(name, created);
+	return created;
+}
+
+function addField(
+	typeEntry: ParsedType,
+	fieldNode: FieldDefinitionNode | InputValueDefinitionNode
+) {
+	typeEntry.fields.set(fieldNode.name.value, typeNodeToString(fieldNode.type));
+}
+
+function addFieldArguments(typeEntry: ParsedType, fieldNode: FieldDefinitionNode) {
+	if (!fieldNode.arguments || !fieldNode.arguments.length) {
+		return;
+	}
+
+	const args = new Map<string, string>();
+
+	for (const argument of fieldNode.arguments) {
+		args.set(argument.name.value, typeNodeToString(argument.type));
+	}
+
+	typeEntry.argsByField.set(fieldNode.name.value, args);
+}
+
+function parseSchema(typeDefs: string): ParsedSchema {
+	const ast = parse(typeDefs);
+	const parsedSchema: ParsedSchema = {
+		types: new Map(),
+	};
+
+	for (const definition of ast.definitions) {
+		consumeDefinition(parsedSchema, definition);
+	}
+
+	return parsedSchema;
+}
+
+function consumeDefinition(parsedSchema: ParsedSchema, definition: DefinitionNode) {
+	switch (definition.kind) {
+		case 'ObjectTypeDefinition':
+		case 'ObjectTypeExtension': {
+			const typeEntry = ensureType(
+				parsedSchema,
+				definition.name.value,
+				'ObjectTypeDefinition'
+			);
+
+			for (const field of definition.fields || []) {
+				addField(typeEntry, field);
+				addFieldArguments(typeEntry, field);
+			}
+			break;
+		}
+		case 'InterfaceTypeDefinition':
+		case 'InterfaceTypeExtension': {
+			const typeEntry = ensureType(
+				parsedSchema,
+				definition.name.value,
+				'InterfaceTypeDefinition'
+			);
+
+			for (const field of definition.fields || []) {
+				addField(typeEntry, field);
+				addFieldArguments(typeEntry, field);
+			}
+			break;
+		}
+		case 'InputObjectTypeDefinition':
+		case 'InputObjectTypeExtension': {
+			const typeEntry = ensureType(
+				parsedSchema,
+				definition.name.value,
+				'InputObjectTypeDefinition'
+			);
+
+			for (const field of definition.fields || []) {
+				addField(typeEntry, field);
+			}
+			break;
+		}
+		case 'EnumTypeDefinition':
+		case 'EnumTypeExtension': {
+			const typeEntry = ensureType(
+				parsedSchema,
+				definition.name.value,
+				'EnumTypeDefinition'
+			);
+
+			for (const value of definition.values || []) {
+				typeEntry.enumValues.add(value.name.value);
+			}
+			break;
+		}
+		case 'UnionTypeDefinition':
+		case 'UnionTypeExtension': {
+			const typeEntry = ensureType(
+				parsedSchema,
+				definition.name.value,
+				'UnionTypeDefinition'
+			);
+
+			for (const member of definition.types || []) {
+				typeEntry.unionMembers.add(member.name.value);
+			}
+			break;
+		}
+		case 'ScalarTypeDefinition':
+		case 'ScalarTypeExtension': {
+			ensureType(parsedSchema, definition.name.value, 'ScalarTypeDefinition');
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+function compareFieldArguments(
+	typeName: string,
+	fieldName: string,
+	beforeArgs: Map<string, string> | undefined,
+	afterArgs: Map<string, string> | undefined,
+	rows: SchemaDiffRow[]
+) {
+	const beforeArgNames = new Set(beforeArgs ? Array.from(beforeArgs.keys()) : []);
+	const afterArgNames = new Set(afterArgs ? Array.from(afterArgs.keys()) : []);
+	const argNames = Array.from(new Set([...beforeArgNames, ...afterArgNames])).sort();
+
+	for (const argName of argNames) {
+		const hadArg = beforeArgs?.has(argName);
+		const hasArg = afterArgs?.has(argName);
+
+		if (!hadArg && hasArg) {
+			rows.push({
+				changeType: 'ARG_ADDED',
+				change: `Argument ${typeName}.${fieldName}(${argName}) added`,
+			});
+			continue;
+		}
+
+		if (hadArg && !hasArg) {
+			rows.push({
+				changeType: 'ARG_REMOVED',
+				change: `Argument ${typeName}.${fieldName}(${argName}) removed`,
+			});
+			continue;
+		}
+
+		const beforeType = beforeArgs?.get(argName);
+		const afterType = afterArgs?.get(argName);
+
+		if (beforeType && afterType && beforeType !== afterType) {
+			rows.push({
+				changeType: 'ARG_TYPE_CHANGED',
+				change: `Argument ${typeName}.${fieldName}(${argName}) type changed from ${beforeType} to ${afterType}`,
+			});
+		}
+	}
+}
+
+function compareFields(
+	typeName: string,
+	beforeType: ParsedType,
+	afterType: ParsedType,
+	rows: SchemaDiffRow[]
+) {
+	const beforeFieldNames = new Set(Array.from(beforeType.fields.keys()));
+	const afterFieldNames = new Set(Array.from(afterType.fields.keys()));
+	const fieldNames = Array.from(
+		new Set([...beforeFieldNames, ...afterFieldNames])
+	).sort();
+
+	for (const fieldName of fieldNames) {
+		const hadField = beforeType.fields.has(fieldName);
+		const hasField = afterType.fields.has(fieldName);
+
+		if (!hadField && hasField) {
+			rows.push({
+				changeType: 'FIELD_ADDED',
+				change: `Field ${typeName}.${fieldName} added`,
+			});
+			continue;
+		}
+
+		if (hadField && !hasField) {
+			rows.push({
+				changeType: 'FIELD_REMOVED',
+				change: `Field ${typeName}.${fieldName} removed`,
+			});
+			continue;
+		}
+
+		const beforeFieldType = beforeType.fields.get(fieldName);
+		const afterFieldType = afterType.fields.get(fieldName);
+
+		if (
+			beforeFieldType &&
+			afterFieldType &&
+			beforeFieldType !== afterFieldType
+		) {
+			rows.push({
+				changeType: 'FIELD_TYPE_CHANGED',
+				change: `Field ${typeName}.${fieldName} type changed from ${beforeFieldType} to ${afterFieldType}`,
+			});
+		}
+
+		compareFieldArguments(
+			typeName,
+			fieldName,
+			beforeType.argsByField.get(fieldName),
+			afterType.argsByField.get(fieldName),
+			rows
+		);
+	}
+}
+
+function compareEnumValues(
+	typeName: string,
+	beforeType: ParsedType,
+	afterType: ParsedType,
+	rows: SchemaDiffRow[]
+) {
+	const beforeValues = new Set(Array.from(beforeType.enumValues));
+	const afterValues = new Set(Array.from(afterType.enumValues));
+	const values = Array.from(new Set([...beforeValues, ...afterValues])).sort();
+
+	for (const value of values) {
+		const hadValue = beforeType.enumValues.has(value);
+		const hasValue = afterType.enumValues.has(value);
+
+		if (!hadValue && hasValue) {
+			rows.push({
+				changeType: 'ENUM_VALUE_ADDED',
+				change: `Enum value ${typeName}.${value} added`,
+			});
+			continue;
+		}
+
+		if (hadValue && !hasValue) {
+			rows.push({
+				changeType: 'ENUM_VALUE_REMOVED',
+				change: `Enum value ${typeName}.${value} removed`,
+			});
+		}
+	}
+}
+
+function compareUnionMembers(
+	typeName: string,
+	beforeType: ParsedType,
+	afterType: ParsedType,
+	rows: SchemaDiffRow[]
+) {
+	const beforeMembers = new Set(Array.from(beforeType.unionMembers));
+	const afterMembers = new Set(Array.from(afterType.unionMembers));
+	const members = Array.from(new Set([...beforeMembers, ...afterMembers])).sort();
+
+	for (const member of members) {
+		const hadMember = beforeType.unionMembers.has(member);
+		const hasMember = afterType.unionMembers.has(member);
+
+		if (!hadMember && hasMember) {
+			rows.push({
+				changeType: 'UNION_MEMBER_ADDED',
+				change: `Union member ${member} added to ${typeName}`,
+			});
+			continue;
+		}
+
+		if (hadMember && !hasMember) {
+			rows.push({
+				changeType: 'UNION_MEMBER_REMOVED',
+				change: `Union member ${member} removed from ${typeName}`,
+			});
+		}
+	}
+}
+
+export function diffSchemaTypeDefs(
+	previousTypeDefs: string | null,
+	nextTypeDefs: string
+): SchemaDiffRow[] {
+	if (!previousTypeDefs) {
+		return [
+			{
+				changeType: 'INITIAL',
+				change: 'Initial schema registered',
+			},
+		];
+	}
+
+	try {
+		const beforeSchema = parseSchema(previousTypeDefs);
+		const afterSchema = parseSchema(nextTypeDefs);
+		const rows: SchemaDiffRow[] = [];
+
+		const beforeTypeNames = new Set(Array.from(beforeSchema.types.keys()));
+		const afterTypeNames = new Set(Array.from(afterSchema.types.keys()));
+		const typeNames = Array.from(
+			new Set([...beforeTypeNames, ...afterTypeNames])
+		).sort();
+
+		for (const typeName of typeNames) {
+			const beforeType = beforeSchema.types.get(typeName);
+			const afterType = afterSchema.types.get(typeName);
+
+			if (!beforeType && afterType) {
+				rows.push({
+					changeType: 'TYPE_ADDED',
+					change: `Type ${typeName} added`,
+				});
+				continue;
+			}
+
+			if (beforeType && !afterType) {
+				rows.push({
+					changeType: 'TYPE_REMOVED',
+					change: `Type ${typeName} removed`,
+				});
+				continue;
+			}
+
+			if (!beforeType || !afterType) {
+				continue;
+			}
+
+			if (beforeType.kind !== afterType.kind) {
+				rows.push({
+					changeType: 'TYPE_KIND_CHANGED',
+					change: `Type ${typeName} kind changed from ${beforeType.kind} to ${afterType.kind}`,
+				});
+			}
+
+			if (
+				afterType.kind === 'ObjectTypeDefinition' ||
+				afterType.kind === 'InterfaceTypeDefinition' ||
+				afterType.kind === 'InputObjectTypeDefinition'
+			) {
+				compareFields(typeName, beforeType, afterType, rows);
+			}
+
+			if (afterType.kind === 'EnumTypeDefinition') {
+				compareEnumValues(typeName, beforeType, afterType, rows);
+			}
+
+			if (afterType.kind === 'UnionTypeDefinition') {
+				compareUnionMembers(typeName, beforeType, afterType, rows);
+			}
+		}
+
+		if (!rows.length) {
+			return [];
+		}
+
+		return rows;
+	} catch (error) {
+		return [
+			{
+				changeType: 'ERROR',
+				change: `Unable to diff schema versions: ${error instanceof Error ? error.message : String(error)}`,
+			},
+		];
+	}
+}

--- a/src/router/assets.ts
+++ b/src/router/assets.ts
@@ -37,7 +37,10 @@ export function indexHtml() {
   </html>`;
 
 		if (!isProduction && req.app?.locals?.vite) {
-			html = await req.app.locals.vite.transformIndexHtml(req.originalUrl, html);
+			html = await req.app.locals.vite.transformIndexHtml(
+				req.originalUrl,
+				html
+			);
 		}
 
 		res.send(html);

--- a/src/router/assets.ts
+++ b/src/router/assets.ts
@@ -9,9 +9,17 @@ export function assetRouter(router) {
 export function indexHtml() {
 	const assetsRootUrl = process.env.ASSETS_URL || '';
 	const assetsVersion = 'latest';
+	const isProduction = process.env.NODE_ENV === 'production';
 
-	return function (req, res) {
-		res.send(`
+	return async function (req, res) {
+		const styleTag = isProduction
+			? `<link rel="stylesheet" type="text/css" href="${assetsRootUrl}/assets/style.css?v=${assetsVersion}">`
+			: '';
+		const scriptTag = isProduction
+			? `<script src="${assetsRootUrl}/assets/management-ui-standalone.js?v=${assetsVersion}" crossorigin></script>`
+			: `<script type="module" src="/client/entry-standalone.tsx"></script>`;
+
+		let html = `
   <!DOCTYPE html>
   <html>
   <head>
@@ -20,13 +28,18 @@ export function indexHtml() {
     <meta name="referrer" content="no-referrer" />
     <title>Schema Registry</title>
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,600i,700,700i" rel="stylesheet">
-    ${`<link rel="stylesheet" type="text/css" href="${assetsRootUrl}/assets/style.css?v=${assetsVersion}">`}
-  </script>
+    ${styleTag}
   </head>
   <body style="margin:0;padding:0;">
     <div id="root"></div>
-    <script src="${assetsRootUrl}/assets/management-ui-standalone.js?v=${assetsVersion}" crossorigin></script>
+    ${scriptTag}
   </body>
-  </html>`);
+  </html>`;
+
+		if (!isProduction && req.app?.locals?.vite) {
+			html = await req.app.locals.vite.transformIndexHtml(req.originalUrl, html);
+		}
+
+		res.send(html);
 	};
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -43,7 +43,7 @@ router.get(
 	})
 );
 
-router.get('/', indexHtml());
+router.get('/', asyncWrap(indexHtml()));
 assetRouter(router);
 
 const supergraphKey = 'supergraph';

--- a/src/setupDev.ts
+++ b/src/setupDev.ts
@@ -4,11 +4,22 @@ import { createServer, ViteDevServer } from 'vite';
 let viteServer: ViteDevServer | null = null;
 
 export default async function setupDev(app: Application) {
+	const hmrPort = Number(process.env.HMR_PORT || 24678);
+	const hmrClientPort = Number(process.env.HMR_CLIENT_PORT || hmrPort);
+
 	viteServer = await createServer({
-		server: { middlewareMode: true },
+		server: {
+			middlewareMode: true,
+			hmr: {
+				host: '0.0.0.0',
+				port: hmrPort,
+				clientPort: hmrClientPort,
+			},
+		},
 		appType: 'custom',
 	});
 
+	app.locals.vite = viteServer;
 	app.use(viteServer.middlewares);
 }
 

--- a/src/worker/analyzeQueries/index.ts
+++ b/src/worker/analyzeQueries/index.ts
@@ -1,5 +1,5 @@
 import { get, isNil } from 'lodash';
-import { TypeInfo } from 'graphql';
+import { Kind, TypeInfo, parse } from 'graphql';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Knex } from 'knex';
 
@@ -10,6 +10,7 @@ import { composeAndValidateSchema } from '../../helpers/federation';
 import schemaModel from '../../database/schema';
 import clientsModel from '../../database/clients';
 import schemaHit from '../../database/schema_hits';
+import operationHit from '../../database/operation_hits';
 import persistedQueries from '../../database/persisted_queries';
 
 import extractQueryFields from './extract-query-properties';
@@ -57,6 +58,7 @@ const analyzer = {
 			);
 
 			schemaHit.init();
+			operationHit.init();
 			clientsModel.init();
 
 			await redis.initRedis();
@@ -157,6 +159,20 @@ const analyzer = {
 				operationName: parsedData.operationName || null,
 			});
 			try {
+				const operationType = getOperationType(
+					parsedData.query,
+					parsedData.operationName
+				);
+				const hour = `${msgDate.toISOString().slice(0, 13)}:00:00.000Z`;
+
+				await operationHit.add({
+					name,
+					version,
+					operationName: parsedData.operationName || 'anonymous',
+					operationType,
+					hour,
+				});
+
 				const processedFields = await analyzer.processSchemaQueryUsage({
 					name,
 					version,
@@ -193,6 +209,7 @@ const analyzer = {
 	processSchemaQueryUsage: async ({ name, version, query, msgDate }) => {
 		const visitedFields = await extractQueryFields(query, analyzer.typeInfo);
 		const day = msgDate.toISOString().slice(0, 10);
+		const hour = `${msgDate.toISOString().slice(0, 13)}:00:00.000Z`;
 
 		for await (const { entity, property } of visitedFields) {
 			// prometheus.logUsedProperty({
@@ -208,11 +225,40 @@ const analyzer = {
 				entity,
 				property,
 				day,
+				hour,
 			});
 		}
 
 		return visitedFields.length;
 	},
 };
+
+function getOperationType(query, operationName) {
+	try {
+		const parsedQuery = parse(query);
+		const operationDefinition = parsedQuery.definitions.find((definition) => {
+			if (definition.kind !== Kind.OPERATION_DEFINITION) {
+				return false;
+			}
+
+			if (!operationName) {
+				return true;
+			}
+
+			return definition.name?.value === operationName;
+		});
+
+		if (
+			operationDefinition &&
+			operationDefinition.kind === Kind.OPERATION_DEFINITION
+		) {
+			return String(operationDefinition.operation || 'UNKNOWN').toUpperCase();
+		}
+	} catch (_) {
+		// ignore parse failures and fallback to UNKNOWN
+	}
+
+	return 'UNKNOWN';
+}
 
 export default analyzer;


### PR DESCRIPTION
## Summary
This PR bundles all current local changes (including out-of-scope updates) into a single branch/PR.

### Frontend
- Split analytics navigation into dedicated tabs and extracted property view into its own `Properties` tab.
- Kept `Entities` and `Operations` as separate views and updated filtering/sorting flows in analytics.
- Added `schema-change-log` client page and wired related UI updates.
- Updated service/schema-related client views:
  - Global search and main/menu tab wiring
  - Logs page updates
  - Service list and schema detail screens
  - Usage graph behavior and query usage rendering
- Updated GraphQL client query documents used by analytics and service usage screens.

### Backend / GraphQL API
- Added hourly operation-hit support in database layer (`src/database/operation_hits.ts`).
- Extended schema-hit handling to include hourly aggregation paths and related logic updates.
- Updated GraphQL schema and resolvers to expose/serve the new usage and analytics data paths.
- Added service-health and schema-change-log helpers and integrated them into routing/app flow.
- Updated schema/controller/router/setup/worker modules to align with the new analytics and usage processing behavior.

### Migrations
- Added migration for schema hit hourly table:
  - `migrations/20260310100000_add_schema_hit_hourly.sql`
- Added migration for schema operation hit hourly table:
  - `migrations/20260310113000_add_schema_operation_hit_hourly.sql`

### Dependencies
- Updated `package.json` and `pnpm-lock.yaml` to include required package changes.

## Files Included
- 29 files changed
- 2680 insertions, 190 deletions

## Validation
- Ran: `pnpm -s oxlint client/analytics/index.jsx`
- Result: 0 warnings, 0 errors

## Notes
- This PR intentionally includes all pending local work in the repository, not only the analytics tab extraction change.


## Additional Update (Clients Moved Under Analytics)
- Removed top-level `Clients` item from the main sidebar menu.
- Added a new `Clients` sub-tab inside Analytics (`Entities` / `Properties` / `Clients` / `Operations`).
- Implemented client usage charting and table view in Analytics:
  - Time-series graph for client usage (last 24h, hourly buckets)
  - Sortable summary table of `client@version` with `hits (1h)` and `hits (24h)`
  - Search and top-N filtering aligned with other analytics tabs
- Added backend GraphQL/API support for client analytics aggregation:
  - New query: `schemaClientHits(granularity, hours)`
  - New type: `SchemaClientHit { clientName, clientVersion, bucket, hits }`
  - Resolver wiring and DB aggregation in `schema_hits` model
