### PR TITLE
Add subscription registry API, UI, and docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+echo "Running Biome checks..."
+
+if [ -x "./node_modules/.bin/biome" ]; then
+  ./node_modules/.bin/biome ci .
+elif command -v pnpm >/dev/null 2>&1; then
+  pnpm exec biome ci .
+elif command -v npx >/dev/null 2>&1; then
+  npx biome ci .
+else
+  echo "Biome is not available. Install dependencies first."
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ sequenceDiagram
 ```
 nvm use
 npm install
+./setup-hooks.sh
 npm run build
 docker-compose  -f docker-compose.base.yml  -f docker-compose.dev.yml up
 ```

--- a/README.md
+++ b/README.md
@@ -215,6 +215,28 @@ Make sure to handle failure.
 
 See [example](examples/schema_registration_client/index.js) for nodejs/ESM.
 
+### How do I register GraphQL subscriptions from event-stream services?
+
+If you have a dedicated websocket/event service (for example `event-stream-filter`) that exposes GraphQL `Subscription` operations, register that SDL separately with:
+
+- `POST /subscriptions/push`
+
+This subscription catalog is intentionally separate from federated supergraph composition:
+
+- `POST /schema/push` is for federated gateway service schemas
+- `POST /subscriptions/push` is for event-stream subscription visibility in UI and analytics
+
+Minimal runtime payload example:
+
+```json
+{
+  "name": "event-stream-filter",
+  "version": "latest",
+  "ws_url": "ws://event-stream-filter:8350/graphql",
+  "type_defs": "type Subscription { onApiaryUpdated: ApiaryEvent } type ApiaryEvent { id: String name: String } type Query { hello: String }"
+}
+```
+
 ### How do I register schema that is being developed?
 
 Usually in production, `POST /schema/push` requires unique `version` that should be unique git or docker hash.
@@ -514,6 +536,44 @@ URL is optional if you use urls from schema-registry as service discovery
 ```
 
 - ❌ 400 "You should not register different type_defs with same version."
+</details>
+
+<details>
+  <summary><h3>🟡 POST /subscriptions/push</h3></summary>
+
+Registers or updates GraphQL subscription SDL for event-stream services.
+This endpoint does not affect federated supergraph composition.
+
+#### Request params (raw body)
+
+```json
+{
+  "name": "event-stream-filter",
+  "version": "latest",
+  "ws_url": "ws://event-stream-filter:8350/graphql",
+  "type_defs": "type Subscription { onApiaryUpdated: ApiaryEvent } type ApiaryEvent { id: String name: String } type Query { hello: String }"
+}
+```
+
+#### Notes
+
+- `name`: service name
+- `version`: runtime/deploy version (`latest` is acceptable for dev)
+- `ws_url`: websocket endpoint for subscriptions
+- `type_defs`: SDL containing `Subscription` definition
+
+</details>
+
+<details>
+  <summary><h3>🟢 GET /subscriptions/latest</h3></summary>
+
+Returns latest registered subscription source per service and extracted subscription definitions.
+
+#### Response shape
+
+- `data.sources[]`: latest subscription source rows (name/version/wsUrl/typeDefs/definitionsCount)
+- `data.definitions[]`: extracted subscription fields (name/payloadType/arguments/source metadata)
+
 </details>
 
 <details>

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -9,12 +9,14 @@ import {
 	PersistedQueriesIcon,
 	LogsIcon,
 	ChangeLogIcon,
+	SubscriptionsIcon,
 } from './MenuIcons';
 import Services from '../schema';
 import Analytics from '../analytics';
 import SupergraphSchema from '../supergraph';
 import PersistedQueries from '../persisted-queries';
 import SchemaChangeLog from '../schema-change-log';
+import Subscriptions from '../subscriptions';
 
 import ServicesTab from '../schema/Tab';
 import PersistedQueriesTab from '../persisted-queries/Tab';
@@ -38,6 +40,12 @@ const UITabs = [
 		icon: <AnalyticsIcon />,
 		href: '/analytics',
 		component: Analytics,
+	},
+	{
+		Title: <span>Subscriptions</span>,
+		icon: <SubscriptionsIcon />,
+		href: '/subscriptions',
+		component: Subscriptions,
 	},
 	{
 		Title: <PersistedQueriesTab />,

--- a/client/components/MenuIcons.jsx
+++ b/client/components/MenuIcons.jsx
@@ -93,3 +93,15 @@ export function ChangeLogIcon() {
 		</svg>
 	);
 }
+
+export function SubscriptionsIcon() {
+	return (
+		<svg {...iconProps}>
+			<path d="M5 7h14" />
+			<path d="M5 12h9" />
+			<path d="M5 17h6" />
+			<path d="M17 10a3 3 0 1 1 0 6" />
+			<path d="M17 13h2.5" />
+		</svg>
+	);
+}

--- a/client/subscriptions/index.jsx
+++ b/client/subscriptions/index.jsx
@@ -41,7 +41,7 @@ function unwrapTypeName(payloadType) {
 		return '';
 	}
 
-	return String(payloadType).replaceAll(/[!\[\]\s]/g, '');
+	return String(payloadType).replaceAll(/[![\]\s]/g, '');
 }
 
 function getPayloadSdlSnippet({ sourceSdl, subscriptionName, payloadType }) {
@@ -108,9 +108,8 @@ function getPayloadSdlSnippet({ sourceSdl, subscriptionName, payloadType }) {
 
 export default function Subscriptions() {
 	const [selectedPayload, setSelectedPayload] = useState(null);
-	const { data: sourcesData, loading: sourcesLoading } = useQuery(
-		SUBSCRIPTION_SOURCES
-	);
+	const { data: sourcesData, loading: sourcesLoading } =
+		useQuery(SUBSCRIPTION_SOURCES);
 	const { data: definitionsData, loading: definitionsLoading } = useQuery(
 		SUBSCRIPTION_DEFINITIONS
 	);
@@ -150,8 +149,7 @@ export default function Subscriptions() {
 	if (!sources.length) {
 		return (
 			<Info>
-				No subscription sources registered yet. Push with POST
-				{' '}
+				No subscription sources registered yet. Push with POST{' '}
 				<code>/subscriptions/push</code>
 			</Info>
 		);
@@ -165,32 +163,46 @@ export default function Subscriptions() {
 			</Info>
 
 			<h3 style={{ margin: '8px 0' }}>Sources</h3>
-			<table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 18 }}>
+			<table
+				style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 18 }}
+			>
 				<thead>
 					<tr>
 						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Name</th>
 						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Version</th>
 						<th style={{ textAlign: 'left', padding: '6px 8px' }}>WS URL</th>
-						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Definitions</th>
+						<th style={{ textAlign: 'left', padding: '6px 8px' }}>
+							Definitions
+						</th>
 						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Updated</th>
 					</tr>
 				</thead>
 				<tbody>
 					{sources.map((source) => (
 						<tr key={source.id}>
-							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+							<td
+								style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+							>
 								{source.name}
 							</td>
-							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+							<td
+								style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+							>
 								{source.version}
 							</td>
-							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+							<td
+								style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+							>
 								<code>{source.wsUrl || '-'}</code>
 							</td>
-							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+							<td
+								style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+							>
 								{source.definitionsCount}
 							</td>
-							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+							<td
+								style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+							>
 								{formatDate(source.updatedTime || source.addedTime)}
 							</td>
 						</tr>
@@ -205,8 +217,12 @@ export default function Subscriptions() {
 				<table style={{ width: '100%', borderCollapse: 'collapse' }}>
 					<thead>
 						<tr>
-							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Subscription</th>
-							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Arguments</th>
+							<th style={{ textAlign: 'left', padding: '6px 8px' }}>
+								Subscription
+							</th>
+							<th style={{ textAlign: 'left', padding: '6px 8px' }}>
+								Arguments
+							</th>
 							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Payload</th>
 							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Updated</th>
 						</tr>
@@ -214,13 +230,19 @@ export default function Subscriptions() {
 					<tbody>
 						{filteredDefinitions.map((row) => (
 							<tr key={`${row.id}-${row.sourceName}`}>
-								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								<td
+									style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+								>
 									<code>{row.name}</code>
 								</td>
-								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								<td
+									style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+								>
 									<code>{formatArguments(row.arguments)}</code>
 								</td>
-								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								<td
+									style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+								>
 									<button
 										type="button"
 										onClick={() => setSelectedPayload(row)}
@@ -237,7 +259,9 @@ export default function Subscriptions() {
 										<code>{row.payloadType}</code>
 									</button>
 								</td>
-								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								<td
+									style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}
+								>
 									{formatDate(row.updatedTime || row.addedTime)}
 								</td>
 							</tr>
@@ -259,7 +283,6 @@ export default function Subscriptions() {
 			) : (
 				<Info>Click a payload type to preview SDL.</Info>
 			)}
-
 		</div>
 	);
 }

--- a/client/subscriptions/index.jsx
+++ b/client/subscriptions/index.jsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { parse, print } from 'graphql';
+
+import SpinnerCenter from '../components/SpinnerCenter';
+import Info from '../components/Info';
+import SourceCodeWithHighlight from '../components/SourceCodeWithHighlight';
+import {
+	SUBSCRIPTION_DEFINITIONS,
+	SUBSCRIPTION_SOURCES,
+} from '../utils/queries';
+
+function formatDate(value) {
+	if (!value) {
+		return '';
+	}
+
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return String(value);
+	}
+
+	return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function formatArguments(argumentsList) {
+	if (!Array.isArray(argumentsList) || argumentsList.length === 0) {
+		return 'none';
+	}
+
+	return argumentsList
+		.map((arg) => {
+			const typeSuffix = arg?.defaultValue ? ` = ${arg.defaultValue}` : '';
+			return `${arg.name}: ${arg.type}${typeSuffix}`;
+		})
+		.join(', ');
+}
+
+function unwrapTypeName(payloadType) {
+	if (!payloadType) {
+		return '';
+	}
+
+	return String(payloadType).replaceAll(/[!\[\]\s]/g, '');
+}
+
+function getPayloadSdlSnippet({ sourceSdl, subscriptionName, payloadType }) {
+	if (!sourceSdl) {
+		return '';
+	}
+
+	try {
+		const ast = parse(sourceSdl);
+		const payloadTypeName = unwrapTypeName(payloadType);
+		const definitions = [];
+
+		const subscriptionType = ast.definitions.find((definition) => {
+			return (
+				definition.kind === 'ObjectTypeDefinition' &&
+				definition.name?.value === 'Subscription'
+			);
+		});
+
+		if (subscriptionType?.fields?.length) {
+			const selectedField = subscriptionType.fields.find(
+				(field) => field.name?.value === subscriptionName
+			);
+
+			if (selectedField) {
+				definitions.push({
+					kind: 'ObjectTypeDefinition',
+					name: { kind: 'Name', value: 'Subscription' },
+					interfaces: [],
+					directives: [],
+					fields: [selectedField],
+				});
+			}
+		}
+
+		const payloadDefinition = ast.definitions.find((definition) => {
+			return definition?.name?.value === payloadTypeName;
+		});
+
+		if (payloadDefinition) {
+			definitions.push(payloadDefinition);
+		}
+
+		const jsonScalar = ast.definitions.find((definition) => {
+			return (
+				definition.kind === 'ScalarTypeDefinition' &&
+				definition.name?.value === 'JSON'
+			);
+		});
+
+		if (jsonScalar) {
+			definitions.push(jsonScalar);
+		}
+
+		if (!definitions.length) {
+			return sourceSdl;
+		}
+
+		return definitions.map((definition) => print(definition)).join('\n\n');
+	} catch (_) {
+		return sourceSdl;
+	}
+}
+
+export default function Subscriptions() {
+	const [selectedPayload, setSelectedPayload] = useState(null);
+	const { data: sourcesData, loading: sourcesLoading } = useQuery(
+		SUBSCRIPTION_SOURCES
+	);
+	const { data: definitionsData, loading: definitionsLoading } = useQuery(
+		SUBSCRIPTION_DEFINITIONS
+	);
+
+	const loading = sourcesLoading || definitionsLoading;
+
+	const sources = sourcesData?.subscriptionSources || [];
+	const definitions = definitionsData?.subscriptionDefinitions || [];
+	const sourceSdlByName = useMemo(() => {
+		const map = new Map();
+		for (const source of sources) {
+			map.set(source.name, source.typeDefs || '');
+		}
+		return map;
+	}, [sources]);
+
+	const filteredDefinitions = useMemo(() => {
+		return definitions;
+	}, [definitions]);
+
+	const selectedPayloadSdl = useMemo(() => {
+		if (!selectedPayload) {
+			return '';
+		}
+
+		return getPayloadSdlSnippet({
+			sourceSdl: sourceSdlByName.get(selectedPayload.sourceName),
+			subscriptionName: selectedPayload.name,
+			payloadType: selectedPayload.payloadType,
+		});
+	}, [selectedPayload, sourceSdlByName]);
+
+	if (loading) {
+		return <SpinnerCenter />;
+	}
+
+	if (!sources.length) {
+		return (
+			<Info>
+				No subscription sources registered yet. Push with POST
+				{' '}
+				<code>/subscriptions/push</code>
+			</Info>
+		);
+	}
+
+	return (
+		<div>
+			<Info>
+				Subscription catalog from event-stream services. This list is separate
+				from federated schema composition.
+			</Info>
+
+			<h3 style={{ margin: '8px 0' }}>Sources</h3>
+			<table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 18 }}>
+				<thead>
+					<tr>
+						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Name</th>
+						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Version</th>
+						<th style={{ textAlign: 'left', padding: '6px 8px' }}>WS URL</th>
+						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Definitions</th>
+						<th style={{ textAlign: 'left', padding: '6px 8px' }}>Updated</th>
+					</tr>
+				</thead>
+				<tbody>
+					{sources.map((source) => (
+						<tr key={source.id}>
+							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								{source.name}
+							</td>
+							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								{source.version}
+							</td>
+							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								<code>{source.wsUrl || '-'}</code>
+							</td>
+							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								{source.definitionsCount}
+							</td>
+							<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+								{formatDate(source.updatedTime || source.addedTime)}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+
+			<h3 style={{ margin: '8px 0' }}>Definitions</h3>
+			{filteredDefinitions.length === 0 ? (
+				<Info>No subscriptions match current filters.</Info>
+			) : (
+				<table style={{ width: '100%', borderCollapse: 'collapse' }}>
+					<thead>
+						<tr>
+							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Subscription</th>
+							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Arguments</th>
+							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Payload</th>
+							<th style={{ textAlign: 'left', padding: '6px 8px' }}>Updated</th>
+						</tr>
+					</thead>
+					<tbody>
+						{filteredDefinitions.map((row) => (
+							<tr key={`${row.id}-${row.sourceName}`}>
+								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+									<code>{row.name}</code>
+								</td>
+								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+									<code>{formatArguments(row.arguments)}</code>
+								</td>
+								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+									<button
+										type="button"
+										onClick={() => setSelectedPayload(row)}
+										style={{
+											padding: 0,
+											border: 0,
+											background: 'none',
+											color: '#1f4ec9',
+											cursor: 'pointer',
+											fontFamily: 'inherit',
+											fontSize: 'inherit',
+										}}
+									>
+										<code>{row.payloadType}</code>
+									</button>
+								</td>
+								<td style={{ borderTop: '1px solid #e5e7eb', padding: '6px 8px' }}>
+									{formatDate(row.updatedTime || row.addedTime)}
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			)}
+
+			<h3 style={{ margin: '18px 0 8px' }}>Payload SDL</h3>
+			{selectedPayloadSdl ? (
+				<div>
+					<div style={{ marginBottom: 8 }}>
+						<strong>{selectedPayload.name}</strong>
+						{' → '}
+						<code>{selectedPayload.payloadType}</code>
+					</div>
+					<SourceCodeWithHighlight code={selectedPayloadSdl} />
+				</div>
+			) : (
+				<Info>Click a payload type to preview SDL.</Info>
+			)}
+
+		</div>
+	);
+}

--- a/client/utils/queries.js
+++ b/client/utils/queries.js
@@ -214,6 +214,38 @@ export const SCHEMA_CHANGE_LOG = gql`
 	}
 `;
 
+export const SUBSCRIPTION_SOURCES = gql`
+	query getSubscriptionSources {
+		subscriptionSources {
+			id
+			name
+			version
+			wsUrl
+			typeDefs
+			addedTime
+			updatedTime
+			definitionsCount
+		}
+	}
+`;
+
+export const SUBSCRIPTION_DEFINITIONS = gql`
+	query getSubscriptionDefinitions($sourceName: String) {
+		subscriptionDefinitions(sourceName: $sourceName) {
+			id
+			sourceId
+			sourceName
+			sourceVersion
+			wsUrl
+			name
+			payloadType
+			arguments
+			addedTime
+			updatedTime
+		}
+	}
+`;
+
 export const SEARCH = gql`
 	query getSearch($query: String!) {
 		search(filter: $query) {

--- a/migrations/20260310170000_add_subscription_registry.sql
+++ b/migrations/20260310170000_add_subscription_registry.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS subscription_sources (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    ws_url VARCHAR(255) NOT NULL DEFAULT '',
+    version VARCHAR(100) NOT NULL DEFAULT '',
+    type_defs TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    updated_time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    added_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (name, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_sources_name_added_time
+    ON subscription_sources(name, added_time DESC);
+
+CREATE TABLE IF NOT EXISTS subscription_definitions (
+    id BIGSERIAL PRIMARY KEY,
+    source_id BIGINT NOT NULL REFERENCES subscription_sources(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL DEFAULT '',
+    payload_type VARCHAR(255) NOT NULL DEFAULT '',
+    arguments JSONB NOT NULL DEFAULT '[]'::jsonb,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    updated_time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    added_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (source_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_definitions_source_id
+    ON subscription_definitions(source_id);

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+echo "Setting up git hooks..."
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOKS_DIR="$SCRIPT_DIR/.githooks"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+  echo "Error: .githooks directory not found"
+  exit 1
+fi
+
+chmod +x "$HOOKS_DIR"/*
+git config core.hooksPath .githooks
+
+echo "Git hooks installed successfully."
+echo "Pre-commit will run Biome checks before each commit."

--- a/src/database/subscriptions.ts
+++ b/src/database/subscriptions.ts
@@ -1,0 +1,255 @@
+import { Kind, parse } from 'graphql';
+import { Knex } from 'knex';
+import { connection, transact } from './index';
+import { rowsFromRaw } from './raw-results';
+
+interface PushSubscriptionSourceInput {
+	name: string;
+	version: string;
+	ws_url?: string;
+	type_defs: string;
+}
+
+interface SubscriptionArgument {
+	name: string;
+	type: string;
+	defaultValue: string | null;
+	required: boolean;
+}
+
+function typeNodeToString(node: any): string {
+	if (!node) {
+		return '';
+	}
+
+	if (node.kind === Kind.NAMED_TYPE) {
+		return node.name.value;
+	}
+
+	if (node.kind === Kind.LIST_TYPE) {
+		return `[${typeNodeToString(node.type)}]`;
+	}
+
+	if (node.kind === Kind.NON_NULL_TYPE) {
+		return `${typeNodeToString(node.type)}!`;
+	}
+
+	return '';
+}
+
+function valueNodeToString(node: any): string | null {
+	if (!node) {
+		return null;
+	}
+
+	if (node.kind === Kind.NULL) {
+		return 'null';
+	}
+
+	if (node.kind === Kind.LIST) {
+		return `[${node.values.map(valueNodeToString).join(', ')}]`;
+	}
+
+	if (node.kind === Kind.OBJECT) {
+		const properties = node.fields.map((field) => {
+			return `${field.name.value}: ${valueNodeToString(field.value)}`;
+		});
+		return `{${properties.join(', ')}}`;
+	}
+
+	if ('value' in node) {
+		return String(node.value);
+	}
+
+	return null;
+}
+
+function extractSubscriptionDefinitions(typeDefs: string) {
+	const ast = parse(typeDefs);
+	const subscriptionType = ast.definitions.find((definition: any) => {
+		return (
+			definition.kind === Kind.OBJECT_TYPE_DEFINITION &&
+			definition.name?.value === 'Subscription'
+		);
+	}) as any;
+
+	if (!subscriptionType?.fields?.length) {
+		return [];
+	}
+
+	return subscriptionType.fields.map((field) => {
+		const args: SubscriptionArgument[] = (field.arguments || []).map((arg) => {
+			const type = typeNodeToString(arg.type);
+			return {
+				name: arg.name.value,
+				type,
+				defaultValue: valueNodeToString(arg.defaultValue),
+				required: type.endsWith('!'),
+			};
+		});
+
+		return {
+			name: field.name.value,
+			payloadType: typeNodeToString(field.type),
+			arguments: args,
+		};
+	});
+}
+
+const subscriptionsModel = {
+	pushSubscriptionSource: async function ({
+		source,
+	}: {
+		source: PushSubscriptionSourceInput;
+	}) {
+		const definitions = extractSubscriptionDefinitions(source.type_defs);
+		const now = new Date();
+
+		return transact(async (trx: Knex) => {
+			const existingSource = await trx('subscription_sources')
+				.where({
+					name: source.name,
+					version: source.version,
+				})
+				.first();
+
+			let sourceId = existingSource?.id;
+
+			if (sourceId) {
+				await trx('subscription_sources')
+					.where({ id: sourceId })
+					.update({
+						ws_url: source.ws_url || '',
+						type_defs: source.type_defs,
+						updated_time: now,
+						is_active: 1,
+					});
+
+				await trx('subscription_definitions')
+					.where({ source_id: sourceId })
+					.del();
+			} else {
+				const inserted = await trx('subscription_sources')
+					.insert({
+						name: source.name,
+						version: source.version,
+						ws_url: source.ws_url || '',
+						type_defs: source.type_defs,
+						added_time: now,
+						updated_time: now,
+					})
+					.returning('id');
+
+				sourceId = Number(inserted[0]?.id || inserted[0]);
+			}
+
+			if (definitions.length > 0) {
+				const rows = definitions.map((definition) => ({
+					source_id: sourceId,
+					name: definition.name,
+					payload_type: definition.payloadType,
+					arguments: JSON.stringify(definition.arguments),
+					added_time: now,
+					updated_time: now,
+				}));
+
+				await trx('subscription_definitions').insert(rows);
+			}
+
+			return {
+				id: Number(sourceId),
+				name: source.name,
+				version: source.version,
+				ws_url: source.ws_url || '',
+				definitionsCount: definitions.length,
+			};
+		});
+	},
+
+	listLatestSources: async function () {
+		const raw = await connection.raw(
+			`SELECT DISTINCT ON (s.name)
+					s.id,
+					s.name,
+					s.version,
+					s.ws_url as "wsUrl",
+					s.type_defs as "typeDefs",
+					s.added_time as "addedTime",
+					s.updated_time as "updatedTime",
+					(
+						SELECT COUNT(*)
+						FROM subscription_definitions d
+						WHERE d.source_id = s.id
+					)::int as "definitionsCount"
+			 FROM subscription_sources s
+			 WHERE s.is_active::text IN ('1','t','true')
+			 ORDER BY s.name, s.added_time DESC, s.id DESC`
+		);
+
+		return rowsFromRaw(raw).map((row) => ({
+			...row,
+			id: Number(row.id),
+			definitionsCount: Number(row.definitionsCount || 0),
+		}));
+	},
+
+	listDefinitions: async function ({
+		sourceName,
+		sourceIds,
+	}: {
+		sourceName?: string;
+		sourceIds?: number[];
+	} = {}) {
+		const params: Array<string | number> = [];
+		let where = `WHERE s.is_active::text IN ('1','t','true')
+					AND d.is_active::text IN ('1','t','true')`;
+
+		if (sourceName) {
+			params.push(sourceName);
+			where += ` AND s.name = ?`;
+		}
+
+		if (sourceIds && sourceIds.length > 0) {
+			where += ` AND s.id IN (${sourceIds.map(() => '?').join(',')})`;
+			params.push(...sourceIds);
+		}
+
+		const raw = await connection.raw(
+			`SELECT d.id,
+					s.id as "sourceId",
+					s.name as "sourceName",
+					s.version as "sourceVersion",
+					s.ws_url as "wsUrl",
+					d.name,
+					d.payload_type as "payloadType",
+					d.arguments,
+					d.added_time as "addedTime",
+					d.updated_time as "updatedTime"
+			 FROM subscription_definitions d
+			 INNER JOIN subscription_sources s ON s.id = d.source_id
+			 ${where}
+			 ORDER BY s.name, d.name`,
+			params
+		);
+
+		return rowsFromRaw(raw).map((row) => {
+			let args = row.arguments;
+			if (typeof args === 'string') {
+				try {
+					args = JSON.parse(args);
+				} catch (_) {
+					args = [];
+				}
+			}
+
+			return {
+				...row,
+				id: Number(row.id),
+				sourceId: Number(row.sourceId),
+				arguments: args || [],
+			};
+		});
+	},
+};
+
+export default subscriptionsModel;

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -17,6 +17,7 @@ import servicesModel from '../database/services';
 import schemaHit from '../database/schema_hits';
 import operationHit from '../database/operation_hits';
 import clientsModel from '../database/clients';
+import subscriptionsModel from '../database/subscriptions';
 
 import PersistedQueriesModel from '../database/persisted_queries';
 import { getServiceHealthStatus } from './service-health';
@@ -35,6 +36,10 @@ export default {
 		service: async (_, { id }, { dataloaders }) =>
 			await dataloaders.services.load(id),
 		serviceCount: async () => await servicesModel.count(),
+		subscriptionSources: async () =>
+			await subscriptionsModel.listLatestSources(),
+		subscriptionDefinitions: async (_, { sourceName }) =>
+			await subscriptionsModel.listDefinitions({ sourceName }),
 		supergraphSDL: async () => await composeSupergraph(connection),
 		schema: async (_, { id }) => {
 			const schema = await schemaModel.getSchemaById(connection, id);

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -10,6 +10,8 @@ export default gql`
 		services(limit: Int, offset: Int): [Service]
 		service(id: Int!): Service
 		serviceCount: Int!
+		subscriptionSources: [SubscriptionSource]
+		subscriptionDefinitions(sourceName: String): [SubscriptionDefinition]
 		supergraphSDL: String!
 		schema(id: Int!): SchemaDefinition!
 		schemas(since: DateTime): [SchemaDefinition]
@@ -172,6 +174,30 @@ export default gql`
 		healthStatus: ServiceHealthStatus!
 
 		schemas(limit: Int, offset: Int, filter: String): [SchemaDefinition!]!
+	}
+
+	type SubscriptionSource {
+		id: Int!
+		name: String!
+		version: String!
+		wsUrl: String
+		typeDefs: String
+		addedTime: DateTime
+		updatedTime: DateTime
+		definitionsCount: Int!
+	}
+
+	type SubscriptionDefinition {
+		id: Int!
+		sourceId: Int!
+		sourceName: String!
+		sourceVersion: String!
+		wsUrl: String
+		name: String!
+		payloadType: String!
+		arguments: JSON
+		addedTime: DateTime
+		updatedTime: DateTime
 	}
 
 	enum ServiceHealthStatus {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ import { indexHtml, assetRouter } from './assets';
 import * as schema from './schema';
 import * as service from './service';
 import * as persistedQuery from './persisted-queries';
+import * as subscriptions from './subscriptions';
 import { logger } from '../logger';
 import servicesModel from '../database/services';
 
@@ -67,6 +68,8 @@ router.delete(
 	asyncWrap(schema.remove)
 );
 router.post('/schema/validate', asyncWrap(schema.validate));
+router.get('/subscriptions/latest', asyncWrap(subscriptions.listLatest));
+router.post('/subscriptions/push', asyncWrap(subscriptions.push));
 
 router.delete(
 	'/service/:name',

--- a/src/router/subscriptions.ts
+++ b/src/router/subscriptions.ts
@@ -1,0 +1,36 @@
+import Joi from 'joi';
+import subscriptionsModel from '../database/subscriptions';
+
+export async function push(req, res) {
+	const source = Joi.attempt(
+		req.body,
+		Joi.object().keys({
+			name: Joi.string().min(3).max(200).required(),
+			version: Joi.string().min(1).max(100).required(),
+			type_defs: Joi.string().required(),
+			ws_url: Joi.string().uri().min(1).max(255).allow(''),
+		})
+	);
+
+	const data = await subscriptionsModel.pushSubscriptionSource({ source });
+
+	return res.json({
+		success: true,
+		data,
+	});
+}
+
+export async function listLatest(req, res) {
+	const sources = await subscriptionsModel.listLatestSources();
+	const definitions = await subscriptionsModel.listDefinitions({
+		sourceIds: sources.map((source) => source.id),
+	});
+
+	return res.json({
+		success: true,
+		data: {
+			sources,
+			definitions,
+		},
+	});
+}

--- a/src/worker/analyzeQueries/index.ts
+++ b/src/worker/analyzeQueries/index.ts
@@ -173,6 +173,16 @@ const analyzer = {
 					hour,
 				});
 
+				// Subscription operations are tracked on operation level.
+				// Field-level schema usage is based on federated query schema
+				// and does not apply to event-stream subscription schema.
+				if (operationType === 'SUBSCRIPTION') {
+					logger.info('Recorded subscription operation hit', {
+						operationName: parsedData.operationName || null,
+					});
+					return;
+				}
+
 				const processedFields = await analyzer.processSchemaQueryUsage({
 					name,
 					version,


### PR DESCRIPTION
## Summary
- add dedicated subscription registry storage (`subscription_sources`, `subscription_definitions`)
- add REST endpoints `POST /subscriptions/push` and `GET /subscriptions/latest`
- expose subscription sources/definitions in GraphQL API
- add Subscriptions UI tab with definition list and clickable payload SDL preview (syntax highlighted)
- keep subscription usage in operation analytics by recording `SUBSCRIPTION` operation hits
- document subscription registration flow and new endpoints in README

## Notes
- subscription catalog is intentionally separate from federated schema composition
- only relevant files were committed; unrelated local untracked files were not included

## Validation
- `./node_modules/.bin/tsc --noEmit` (graphql-schema-registry)
